### PR TITLE
feature/endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dco3"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2021"
 authors = ["Octavio Simone"]
 repository = "https://github.com/unbekanntes-pferd/dco3"
@@ -14,10 +14,9 @@ description = "Async API wrapper for DRACOON in Rust."
 
 
 [dependencies]
-# HTTP client (currently pinned at 0.11.27 due to reqwest-retry and reqwest-middleware)
-reqwest = {version = "0.11.27", features = ["json", "stream"]}
-reqwest-middleware = "0.2.5"
-reqwest-retry = "0.4.0"
+reqwest = {version = "0.12.3", features = ["json", "stream"]}
+reqwest-middleware = {version = "0.3.0", features = ["json"]}
+reqwest-retry = "0.5.0"
 
 # crypto 
 dco3_crypto = "0.6.0"

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -414,7 +414,7 @@ impl DracoonClient<Disconnected> {
             client_secret: self.client_secret.clone(),
             connection: Container::new_from(connection),
             additional_connections: self.additional_connections.clone(),
-            token_rotation: self.token_rotation.clone(),
+            token_rotation: self.token_rotation,
             curr_connection: self.curr_connection.clone(),
             base_url: self.base_url.clone(),
             redirect_uri: self.redirect_uri.clone(),
@@ -579,11 +579,6 @@ impl DracoonClient<Connected> {
             stream_http: self.stream_http,
             provisioning_token: None,
         })
-    }
-
-    /// Returns the base url of the DRACOON instance
-    pub fn get_base_url(&self) -> &Url {
-        &self.base_url
     }
 
     /// Returns the token url for any OAuth2 flow
@@ -771,12 +766,6 @@ impl DracoonClient<Connected> {
             .expect("Connected client has no connection")
             .is_expired()
     }
-
-    pub fn build_api_url(&self, url_part: &str) -> Url {
-        self.base_url
-            .join(url_part)
-            .expect("Invalid base url or url part")
-    }
 }
 
 impl DracoonClient<Provisioning> {
@@ -787,10 +776,18 @@ impl DracoonClient<Provisioning> {
             .expect("Provisioning client has no token")
             .to_string()
     }
+}
 
+impl<S> DracoonClient<S> {
     /// Returns the base url of the DRACOON instance
     pub fn get_base_url(&self) -> &Url {
         &self.base_url
+    }
+
+    pub fn build_api_url(&self, url_part: &str) -> Url {
+        self.base_url
+            .join(url_part)
+            .expect("Invalid base url or url part")
     }
 }
 
@@ -1345,7 +1342,7 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(auth_res)
-            .match_header(USER_AGENT, APP_USER_AGENT)
+            .match_header(USER_AGENT.as_str(), APP_USER_AGENT)
             .create();
 
         let dracoon = get_test_client(&base_url);
@@ -1371,7 +1368,7 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(auth_res)
-            .match_header(USER_AGENT, custom_user_agent.as_str())
+            .match_header(USER_AGENT.as_str(), custom_user_agent.as_str())
             .create();
 
         let dracoon = DracoonClientBuilder::new()

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -377,7 +377,7 @@ impl DracoonClient<Disconnected> {
 
     /// Connects to DRACOON using any of the supported OAuth2 flows
     pub async fn connect(
-        self,
+        &self,
         oauth_flow: OAuth2Flow,
     ) -> Result<DracoonClient<Connected>, DracoonClientError> {
         let connection = match oauth_flow {
@@ -410,17 +410,17 @@ impl DracoonClient<Disconnected> {
         }
 
         Ok(DracoonClient {
-            client_id: self.client_id,
-            client_secret: self.client_secret,
+            client_id: self.client_id.clone(),
+            client_secret: self.client_secret.clone(),
             connection: Container::new_from(connection),
-            additional_connections: self.additional_connections,
-            token_rotation: self.token_rotation,
-            curr_connection: self.curr_connection,
-            base_url: self.base_url,
-            redirect_uri: self.redirect_uri,
+            additional_connections: self.additional_connections.clone(),
+            token_rotation: self.token_rotation.clone(),
+            curr_connection: self.curr_connection.clone(),
+            base_url: self.base_url.clone(),
+            redirect_uri: self.redirect_uri.clone(),
             connected: PhantomData,
-            http: self.http,
-            stream_http: self.stream_http,
+            http: self.http.clone(),
+            stream_http: self.stream_http.clone(),
             provisioning_token: None,
         })
     }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -771,6 +771,12 @@ impl DracoonClient<Connected> {
             .expect("Connected client has no connection")
             .is_expired()
     }
+
+    pub fn build_api_url(&self, url_part: &str) -> Url {
+        self.base_url
+            .join(url_part)
+            .expect("Invalid base url or url part")
+    }
 }
 
 impl DracoonClient<Provisioning> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,7 +9,7 @@ use crate::constants::{
     CONFIG_PRODUCT_PACKAGES, CONFIG_PRODUCT_PACKAGES_CURRENT, CONFIG_S3_TAGS, DRACOON_API_PREFIX,
 };
 use crate::utils::FromResponse;
-use crate::{auth::Connected, Dracoon, DracoonClientError};
+use crate::{auth::Connected, DracoonClientError};
 
 pub use self::models::*;
 
@@ -41,17 +41,20 @@ pub trait Config {
 }
 
 #[async_trait]
-impl Config for Dracoon<Connected> {
+impl Config for ConfigEndpoint<Connected> {
     async fn get_defaults(&self) -> Result<SystemDefaults, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{CONFIG_BASE}/{CONFIG_DEFAULTS}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -61,13 +64,16 @@ impl Config for Dracoon<Connected> {
     async fn get_general_settings(&self) -> Result<GeneralSettingsInfo, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{CONFIG_BASE}/{CONFIG_GENERAL}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -79,13 +85,16 @@ impl Config for Dracoon<Connected> {
     ) -> Result<InfrastructureProperties, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{CONFIG_BASE}/{CONFIG_INFRASTRUCTURE}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -97,13 +106,16 @@ impl Config for Dracoon<Connected> {
     ) -> Result<ClassificationPoliciesConfig, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{CONFIG_BASE}/{CONFIG_POLICIES}/{CONFIG_CLASSIFICATION_POLICIES}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -115,13 +127,16 @@ impl Config for Dracoon<Connected> {
             "/{DRACOON_API_PREFIX}/{CONFIG_BASE}/{CONFIG_POLICIES}/{CONFIG_PASSWORD_POLICIES}"
         );
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -131,13 +146,16 @@ impl Config for Dracoon<Connected> {
     async fn get_algorithms(&self) -> Result<AlgorithmVersionInfoList, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{CONFIG_BASE}/{CONFIG_ALGORITHMS}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -147,13 +165,16 @@ impl Config for Dracoon<Connected> {
     async fn get_product_packages(&self) -> Result<ProductPackageResponseList, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{CONFIG_BASE}/{CONFIG_PRODUCT_PACKAGES}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -165,13 +186,16 @@ impl Config for Dracoon<Connected> {
     ) -> Result<ProductPackageResponseList, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{CONFIG_BASE}/{CONFIG_PRODUCT_PACKAGES}/{CONFIG_PRODUCT_PACKAGES_CURRENT}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -181,13 +205,16 @@ impl Config for Dracoon<Connected> {
     async fn get_s3_tags(&self) -> Result<S3TagList, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{CONFIG_BASE}/{CONFIG_S3_TAGS}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -219,7 +246,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let defaults = client.get_defaults().await.unwrap();
+        let defaults = client.config.get_defaults().await.unwrap();
 
         defaults_mock.assert();
 
@@ -244,7 +271,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let general_settings = client.get_general_settings().await.unwrap();
+        let general_settings = client.config.get_general_settings().await.unwrap();
 
         general_settings_mock.assert();
 
@@ -298,7 +325,8 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let infrastructure_properties = client.get_infrastructure_properties().await.unwrap();
+        let infrastructure_properties =
+            client.config.get_infrastructure_properties().await.unwrap();
 
         infrastructure_properties_mock.assert();
 
@@ -333,7 +361,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let classification_policies = client.get_classification_policies().await.unwrap();
+        let classification_policies = client.config.get_classification_policies().await.unwrap();
 
         classification_policies_mock.assert();
 
@@ -364,7 +392,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let password_policies = client.get_password_policies().await.unwrap();
+        let password_policies = client.config.get_password_policies().await.unwrap();
 
         password_policies_mock.assert();
 
@@ -482,7 +510,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let algorithms = client.get_algorithms().await.unwrap();
+        let algorithms = client.config.get_algorithms().await.unwrap();
 
         algorithms_mock.assert();
 
@@ -512,7 +540,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let product_packages = client.get_product_packages().await.unwrap();
+        let product_packages = client.config.get_product_packages().await.unwrap();
 
         product_packages_mock.assert();
 
@@ -545,7 +573,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let product_packages = client.get_current_product_package().await.unwrap();
+        let product_packages = client.config.get_current_product_package().await.unwrap();
 
         product_packages_mock.assert();
 
@@ -577,7 +605,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let s3_tags = client.get_s3_tags().await.unwrap();
+        let s3_tags = client.config.get_s3_tags().await.unwrap();
 
         s3_tags_mock.assert();
 

--- a/src/config/models.rs
+++ b/src/config/models.rs
@@ -1,8 +1,29 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use dco3_derive::FromResponse;
 use serde::Deserialize;
 
-use crate::nodes::UserInfo;
+use crate::{auth::DracoonClient, nodes::UserInfo};
+
+#[derive(Clone)]
+pub struct ConfigEndpoint<S> {
+    client: Arc<DracoonClient<S>>,
+    state: std::marker::PhantomData<S>,
+}
+
+impl<S> ConfigEndpoint<S> {
+    pub fn new(client: Arc<DracoonClient<S>>) -> Self {
+        Self {
+            client,
+            state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn client(&self) -> &Arc<DracoonClient<S>> {
+        &self.client
+    }
+}
 
 #[derive(Debug, Deserialize, Clone, FromResponse)]
 #[serde(rename_all = "camelCase")]

--- a/src/groups/groups.rs
+++ b/src/groups/groups.rs
@@ -6,14 +6,14 @@ use crate::{
     constants::{DRACOON_API_PREFIX, GROUPS_BASE, GROUPS_LAST_ADMIN_ROOMS, GROUPS_USERS},
     models::ListAllParams,
     utils::FromResponse,
-    Dracoon, DracoonClientError,
+    DracoonClientError,
 };
 
 use super::models::*;
 use super::Groups;
 
 #[async_trait]
-impl Groups for Dracoon<Connected> {
+impl Groups for GroupsEndpoint<Connected> {
     async fn get_groups(
         &self,
         params: Option<ListAllParams>,
@@ -21,7 +21,7 @@ impl Groups for Dracoon<Connected> {
         let params = params.unwrap_or_default();
         let url_part = format!("/{DRACOON_API_PREFIX}/{GROUPS_BASE}");
 
-        let mut api_url = self.build_api_url(&url_part);
+        let mut api_url = self.client().build_api_url(&url_part);
 
         let filters = params.filter_to_string();
         let sorts = params.sort_to_string();
@@ -35,10 +35,10 @@ impl Groups for Dracoon<Connected> {
             .finish();
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .send()
             .await?;
 
@@ -48,13 +48,13 @@ impl Groups for Dracoon<Connected> {
     async fn create_group(&self, group: CreateGroupRequest) -> Result<Group, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{GROUPS_BASE}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .header(header::CONTENT_TYPE, "application/json")
             .json(&group)
             .send()
@@ -66,13 +66,13 @@ impl Groups for Dracoon<Connected> {
     async fn get_group(&self, group_id: u64) -> Result<Group, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{GROUPS_BASE}/{group_id}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .send()
             .await?;
 
@@ -86,13 +86,13 @@ impl Groups for Dracoon<Connected> {
     ) -> Result<Group, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{GROUPS_BASE}/{group_id}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .header(header::CONTENT_TYPE, "application/json")
             .json(&group)
             .send()
@@ -104,13 +104,13 @@ impl Groups for Dracoon<Connected> {
     async fn delete_group(&self, group_id: u64) -> Result<(), DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{GROUPS_BASE}/{group_id}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .send()
             .await?;
 
@@ -130,13 +130,13 @@ impl Groups for Dracoon<Connected> {
     ) -> Result<GroupUserList, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{GROUPS_BASE}/{group_id}/{GROUPS_USERS}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .send()
             .await?;
 
@@ -150,13 +150,13 @@ impl Groups for Dracoon<Connected> {
     ) -> Result<Group, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{GROUPS_BASE}/{group_id}/{GROUPS_USERS}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .header(header::CONTENT_TYPE, "application/json")
             .json(&user_ids)
             .send()
@@ -172,13 +172,13 @@ impl Groups for Dracoon<Connected> {
     ) -> Result<Group, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{GROUPS_BASE}/{group_id}/{GROUPS_USERS}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .header(header::CONTENT_TYPE, "application/json")
             .json(&user_ids)
             .send()
@@ -194,13 +194,13 @@ impl Groups for Dracoon<Connected> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{GROUPS_BASE}/{group_id}/{GROUPS_LAST_ADMIN_ROOMS}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .send()
             .await?;
 

--- a/src/groups/groups.rs
+++ b/src/groups/groups.rs
@@ -38,7 +38,10 @@ impl Groups for GroupsEndpoint<Connected> {
             .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -54,7 +57,10 @@ impl Groups for GroupsEndpoint<Connected> {
             .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&group)
             .send()
@@ -72,7 +78,10 @@ impl Groups for GroupsEndpoint<Connected> {
             .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -92,7 +101,10 @@ impl Groups for GroupsEndpoint<Connected> {
             .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&group)
             .send()
@@ -110,7 +122,10 @@ impl Groups for GroupsEndpoint<Connected> {
             .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -136,7 +151,10 @@ impl Groups for GroupsEndpoint<Connected> {
             .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -156,7 +174,10 @@ impl Groups for GroupsEndpoint<Connected> {
             .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&user_ids)
             .send()
@@ -178,7 +199,10 @@ impl Groups for GroupsEndpoint<Connected> {
             .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&user_ids)
             .send()
@@ -200,7 +224,10 @@ impl Groups for GroupsEndpoint<Connected> {
             .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -34,7 +34,7 @@ pub trait Groups {
     ///     .with_sort(GroupsSortBy::name(SortOrder::Desc))
     ///     .build();
     /// // pass None if you don't want to use any params
-    /// let groups = dracoon.get_groups(Some(params)).await.unwrap();
+    /// let groups = dracoon.groups.get_groups(Some(params)).await.unwrap();
     ///
     /// # }
     /// ```
@@ -58,7 +58,7 @@ pub trait Groups {
     /// #  .unwrap();
     /// // There's no builder - use new and set the required field
     /// let group = CreateGroupRequest::new("test_group", None);
-    /// let group = dracoon.create_group(group).await.unwrap();
+    /// let group = dracoon.groups.create_group(group).await.unwrap();
     /// # }
     /// ```
     async fn create_group(&self, group: CreateGroupRequest) -> Result<Group, DracoonClientError>;
@@ -76,7 +76,7 @@ pub trait Groups {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let group = dracoon.get_group(123).await.unwrap();
+    /// let group = dracoon.groups.get_group(123).await.unwrap();
     /// # }
     /// ```
     async fn get_group(&self, group_id: u64) -> Result<Group, DracoonClientError>;
@@ -96,7 +96,7 @@ pub trait Groups {
     /// #  .unwrap();
     /// // There's no builder - use relevant methods to set the fields (name or expiration)
     /// let update = UpdateGroupRequest::name("new_name");
-    /// let group = dracoon.update_group(123, update).await.unwrap();
+    /// let group = dracoon.groups.update_group(123, update).await.unwrap();
     /// # }
     /// ```
     async fn update_group(
@@ -118,7 +118,7 @@ pub trait Groups {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// dracoon.delete_group(123).await.unwrap();
+    /// dracoon.groups.delete_group(123).await.unwrap();
     /// # }
     /// ```
     async fn delete_group(&self, group_id: u64) -> Result<(), DracoonClientError>;
@@ -141,7 +141,7 @@ pub trait Groups {
     ///     .with_filter(GroupUsersFilter::user_contains("test"))
     ///     .build();
     /// // pass None if you don't want to use any params
-    /// let groups = dracoon.get_group_users(123, Some(params)).await.unwrap();
+    /// let groups = dracoon.groups.get_group_users(123, Some(params)).await.unwrap();
     ///
     /// # }
     /// ```
@@ -166,10 +166,10 @@ pub trait Groups {
     /// #  .unwrap();
     /// // you can pass a vec and use into()
     /// let user_ids = vec![1, 2, 3];
-    /// dracoon.add_group_users(123, user_ids.into()).await.unwrap();
+    /// dracoon.groups.add_group_users(123, user_ids.into()).await.unwrap();
     /// // or use the ChangeGroupMembersRequest
     /// let user_ids = ChangeGroupMembersRequest::new(vec![1, 2, 3]);
-    /// dracoon.add_group_users(123, user_ids).await.unwrap();
+    /// dracoon.groups.add_group_users(123, user_ids).await.unwrap();
     /// # }
     /// ```
     async fn add_group_users(
@@ -193,10 +193,10 @@ pub trait Groups {
     /// #  .unwrap();
     /// // you can pass a vec and use into()
     /// let user_ids = vec![1, 2, 3];
-    /// dracoon.add_group_users(123, user_ids.into()).await.unwrap();
+    /// dracoon.groups.add_group_users(123, user_ids.into()).await.unwrap();
     /// // or use the ChangeGroupMembersRequest
     /// let user_ids = ChangeGroupMembersRequest::new(vec![1, 2, 3]);
-    /// dracoon.remove_group_users(123, user_ids).await.unwrap();
+    /// dracoon.groups.remove_group_users(123, user_ids).await.unwrap();
     /// # }
     /// ```
     async fn remove_group_users(
@@ -218,7 +218,7 @@ pub trait Groups {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let rooms = dracoon.get_group_last_admin_rooms(123).await.unwrap();
+    /// let rooms = dracoon.groups.get_group_last_admin_rooms(123).await.unwrap();
     /// # }
     /// ```
     async fn get_group_last_admin_rooms(

--- a/src/groups/models.rs
+++ b/src/groups/models.rs
@@ -21,7 +21,7 @@ pub struct GroupsEndpoint<S> {
     state: std::marker::PhantomData<S>,
 }
 
-impl <S> GroupsEndpoint<S> {
+impl<S> GroupsEndpoint<S> {
     pub fn new(client: Arc<DracoonClient<S>>) -> Self {
         Self {
             client,

--- a/src/groups/models.rs
+++ b/src/groups/models.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dco3_derive::FromResponse;
@@ -5,13 +7,32 @@ use reqwest::Response;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    auth::DracoonErrorResponse,
+    auth::{DracoonClient, DracoonErrorResponse},
     models::{FilterOperator, FilterQuery, ObjectExpiration, RangedItems, SortOrder, SortQuery},
     nodes::models::UserInfo,
     user::models::RoleList,
     utils::{parse_body, FromResponse},
     DracoonClientError,
 };
+
+#[derive(Clone)]
+pub struct GroupsEndpoint<S> {
+    client: Arc<DracoonClient<S>>,
+    state: std::marker::PhantomData<S>,
+}
+
+impl <S> GroupsEndpoint<S> {
+    pub fn new(client: Arc<DracoonClient<S>>) -> Self {
+        Self {
+            client,
+            state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn client(&self) -> &Arc<DracoonClient<S>> {
+        &self.client
+    }
+}
 
 #[derive(Debug, Deserialize, Clone, FromResponse)]
 #[serde(rename_all = "camelCase")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,7 @@
 //! ## Examples
 //! For an example client implementation, see the [dccmd-rs](https://github.com/unbekanntes-pferd/dccmd-rs) repository.
 
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
 
 use auth::Provisioning;
 use dco3_crypto::PlainUserKeyPairContainer;
@@ -441,13 +441,14 @@ pub mod utils;
 /// DRACOON struct - implements all API calls via traits
 #[derive(Clone)]
 pub struct Dracoon<State = Disconnected> {
-    client: DracoonClient<State>,
+    client: Arc<DracoonClient<State>>,
     state: PhantomData<State>,
     user_info: Container<UserAccount>,
     keypair: Container<PlainUserKeyPairContainer>,
     system_info: Container<SystemInfo>,
     encryption_secret: Option<String>,
-}
+    //pub user: impl UserAccountKeyPairs + User
+} 
 
 /// Builder for the `Dracoon` struct.
 /// Requires a base url, client id and client secret.
@@ -546,7 +547,7 @@ impl DracoonBuilder {
         let dracoon = self.client_builder.build()?;
 
         Ok(Dracoon {
-            client: dracoon,
+            client: Arc::new(dracoon),
             state: PhantomData,
             user_info: Container::new(),
             keypair: Container::new(),
@@ -560,7 +561,7 @@ impl DracoonBuilder {
         let dracoon = self.client_builder.build_provisioning()?;
 
         Ok(Dracoon {
-            client: dracoon,
+            client: Arc::new(dracoon),
             state: PhantomData,
             user_info: Container::new(),
             keypair: Container::new(),
@@ -582,7 +583,7 @@ impl Dracoon<Disconnected> {
         let client = self.client.connect(oauth_flow).await?;
 
         let mut dracoon = Dracoon {
-            client,
+            client: Arc::new(client),
             state: PhantomData,
             user_info: Container::new(),
             keypair: Container::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,6 +399,7 @@ use auth::Provisioning;
 use dco3_crypto::PlainUserKeyPairContainer;
 use public::{PublicEndpoint, SystemInfo};
 use reqwest::Url;
+use shares::SharesEndpoint;
 use user::UserEndpoint;
 
 use self::{
@@ -448,6 +449,7 @@ pub struct Dracoon<State = Disconnected> {
     keypair: Container<PlainUserKeyPairContainer>,
     system_info: Container<SystemInfo>,
     encryption_secret: Option<String>,
+    pub shares: SharesEndpoint<State>,
     pub user: UserEndpoint<State>,
     pub public: PublicEndpoint<State>,
 } 
@@ -550,6 +552,7 @@ impl DracoonBuilder {
         let dracoon = Arc::new(dracoon);
         let user_endpoint = UserEndpoint::new(Arc::clone(&dracoon));
         let public_endpoint = PublicEndpoint::new(Arc::clone(&dracoon));
+        let shares_endpoint = SharesEndpoint::new(Arc::clone(&dracoon));
 
         Ok(Dracoon {
             client: dracoon,
@@ -560,6 +563,7 @@ impl DracoonBuilder {
             encryption_secret: self.encryption_secret,
             user: user_endpoint,
             public: public_endpoint,
+            shares: shares_endpoint,
         })
     }
 
@@ -569,6 +573,7 @@ impl DracoonBuilder {
         let dracoon = Arc::new(dracoon);
         let user_endpoint = UserEndpoint::new(Arc::clone(&dracoon));
         let public_endpoint = PublicEndpoint::new(Arc::clone(&dracoon));
+        let shares_endpoint = SharesEndpoint::new(Arc::clone(&dracoon));
 
         Ok(Dracoon {
             client: dracoon,
@@ -579,6 +584,7 @@ impl DracoonBuilder {
             encryption_secret: None,
             user: user_endpoint,
             public: public_endpoint,
+            shares: shares_endpoint,
         })
     }
 }
@@ -597,6 +603,7 @@ impl Dracoon<Disconnected> {
         let connected_client = Arc::new(client);
         let user_endpoint = UserEndpoint::new(Arc::clone(&connected_client));
         let public_endpoint = PublicEndpoint::new(Arc::clone(&connected_client));
+        let shares_endpoint = SharesEndpoint::new(Arc::clone(&connected_client));
 
         let mut dracoon = Dracoon {
             client: connected_client,
@@ -607,6 +614,7 @@ impl Dracoon<Disconnected> {
             encryption_secret: self.encryption_secret,
             user: user_endpoint,
             public: public_endpoint,
+            shares: shares_endpoint,
         };
 
         if let Some(encryption_secret) = dracoon.encryption_secret.clone() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!       .await
 //!       .unwrap();
 //!
-//!   let user_info = dracoon.get_user_account().await.unwrap();
+//!   let user_info = dracoon.user.get_user_account().await.unwrap();
 //!   println!("User info: {:?}", user_info);
 //! }
 //!```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,7 @@ use public::{PublicEndpoint, SystemInfo};
 use reqwest::Url;
 use shares::SharesEndpoint;
 use user::UserEndpoint;
+use users::UsersEndpoint;
 
 use self::{
     auth::{Connected, Disconnected},
@@ -451,6 +452,7 @@ pub struct Dracoon<State = Disconnected> {
     encryption_secret: Option<String>,
     pub shares: SharesEndpoint<State>,
     pub user: UserEndpoint<State>,
+    pub users: UsersEndpoint<State>,
     pub public: PublicEndpoint<State>,
 } 
 
@@ -553,6 +555,7 @@ impl DracoonBuilder {
         let user_endpoint = UserEndpoint::new(Arc::clone(&dracoon));
         let public_endpoint = PublicEndpoint::new(Arc::clone(&dracoon));
         let shares_endpoint = SharesEndpoint::new(Arc::clone(&dracoon));
+        let users_endpoint = UsersEndpoint::new(Arc::clone(&dracoon));
 
         Ok(Dracoon {
             client: dracoon,
@@ -564,6 +567,7 @@ impl DracoonBuilder {
             user: user_endpoint,
             public: public_endpoint,
             shares: shares_endpoint,
+            users: users_endpoint,
         })
     }
 
@@ -574,6 +578,7 @@ impl DracoonBuilder {
         let user_endpoint = UserEndpoint::new(Arc::clone(&dracoon));
         let public_endpoint = PublicEndpoint::new(Arc::clone(&dracoon));
         let shares_endpoint = SharesEndpoint::new(Arc::clone(&dracoon));
+        let users_endpoint = UsersEndpoint::new(Arc::clone(&dracoon));
 
         Ok(Dracoon {
             client: dracoon,
@@ -585,6 +590,7 @@ impl DracoonBuilder {
             user: user_endpoint,
             public: public_endpoint,
             shares: shares_endpoint,
+            users: users_endpoint,
         })
     }
 }
@@ -604,6 +610,7 @@ impl Dracoon<Disconnected> {
         let user_endpoint = UserEndpoint::new(Arc::clone(&connected_client));
         let public_endpoint = PublicEndpoint::new(Arc::clone(&connected_client));
         let shares_endpoint = SharesEndpoint::new(Arc::clone(&connected_client));
+        let users_endpoint = UsersEndpoint::new(Arc::clone(&connected_client));
 
         let mut dracoon = Dracoon {
             client: connected_client,
@@ -615,6 +622,7 @@ impl Dracoon<Disconnected> {
             user: user_endpoint,
             public: public_endpoint,
             shares: shares_endpoint,
+            users: users_endpoint,
         };
 
         if let Some(encryption_secret) = dracoon.encryption_secret.clone() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@
 //!
 //! // this takes a mandatory name and optional expiration
 //! let group = CreateGroupRequest::new("My Group", None);
-//! let group = dracoon.create_group(group).await.unwrap();
+//! let group = dracoon.groups.create_group(group).await.unwrap();
 //!
 //! # }
 //! ```
@@ -397,6 +397,7 @@ use std::{marker::PhantomData, sync::Arc};
 
 use auth::Provisioning;
 use dco3_crypto::PlainUserKeyPairContainer;
+use groups::GroupsEndpoint;
 use public::{PublicEndpoint, SystemInfo};
 use reqwest::Url;
 use shares::SharesEndpoint;
@@ -450,6 +451,7 @@ pub struct Dracoon<State = Disconnected> {
     keypair: Container<PlainUserKeyPairContainer>,
     system_info: Container<SystemInfo>,
     encryption_secret: Option<String>,
+    pub groups: GroupsEndpoint<State>,
     pub shares: SharesEndpoint<State>,
     pub user: UserEndpoint<State>,
     pub users: UsersEndpoint<State>,
@@ -556,6 +558,7 @@ impl DracoonBuilder {
         let public_endpoint = PublicEndpoint::new(Arc::clone(&dracoon));
         let shares_endpoint = SharesEndpoint::new(Arc::clone(&dracoon));
         let users_endpoint = UsersEndpoint::new(Arc::clone(&dracoon));
+        let groups_endpoint = GroupsEndpoint::new(Arc::clone(&dracoon));
 
         Ok(Dracoon {
             client: dracoon,
@@ -568,6 +571,7 @@ impl DracoonBuilder {
             public: public_endpoint,
             shares: shares_endpoint,
             users: users_endpoint,
+            groups: groups_endpoint,
         })
     }
 
@@ -579,6 +583,7 @@ impl DracoonBuilder {
         let public_endpoint = PublicEndpoint::new(Arc::clone(&dracoon));
         let shares_endpoint = SharesEndpoint::new(Arc::clone(&dracoon));
         let users_endpoint = UsersEndpoint::new(Arc::clone(&dracoon));
+        let groups_endpoint = GroupsEndpoint::new(Arc::clone(&dracoon));
 
         Ok(Dracoon {
             client: dracoon,
@@ -591,6 +596,7 @@ impl DracoonBuilder {
             public: public_endpoint,
             shares: shares_endpoint,
             users: users_endpoint,
+            groups: groups_endpoint,
         })
     }
 }
@@ -611,6 +617,7 @@ impl Dracoon<Disconnected> {
         let public_endpoint = PublicEndpoint::new(Arc::clone(&connected_client));
         let shares_endpoint = SharesEndpoint::new(Arc::clone(&connected_client));
         let users_endpoint = UsersEndpoint::new(Arc::clone(&connected_client));
+        let groups_endpoint = GroupsEndpoint::new(Arc::clone(&connected_client));
 
         let mut dracoon = Dracoon {
             client: connected_client,
@@ -623,6 +630,7 @@ impl Dracoon<Disconnected> {
             public: public_endpoint,
             shares: shares_endpoint,
             users: users_endpoint,
+            groups: groups_endpoint,
         };
 
         if let Some(encryption_secret) = dracoon.encryption_secret.clone() {

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -36,13 +36,13 @@ pub trait Nodes {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let nodes = dracoon.get_nodes(None, None, None).await.unwrap();
+    /// let nodes = dracoon.nodes.get_nodes(None, None, None).await.unwrap();
     ///
     /// // get all nodes for a parent
-    /// let nodes = dracoon.get_nodes(Some(123), None, None).await.unwrap();
+    /// let nodes = dracoon.nodes.get_nodes(Some(123), None, None).await.unwrap();
     ///
     /// // get all nodes visible as room manager / admin
-    /// let nodes = dracoon.get_nodes(None, Some(true), None).await.unwrap();
+    /// let nodes = dracoon.nodes.get_nodes(None, Some(true), None).await.unwrap();
     ///
     /// // use filtering and sorting
     /// let params = ListAllParams::builder()
@@ -51,7 +51,7 @@ pub trait Nodes {
     ///    .with_sort(NodesSortBy::name(SortOrder::Desc))
     ///    .build();
     ///
-    /// let nodes = dracoon.get_nodes(None, None, Some(params)).await.unwrap();
+    /// let nodes = dracoon.nodes.get_nodes(None, None, Some(params)).await.unwrap();
     /// # }
     /// ```
     async fn get_nodes(
@@ -74,7 +74,7 @@ pub trait Nodes {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let node = dracoon.get_node_from_path("/foo/bar").await.unwrap();
+    /// let node = dracoon.nodes.get_node_from_path("/foo/bar").await.unwrap();
     /// match node {
     ///    Some(node) => println!("Found node: {}", node.name),
     ///    None => println!("Node not found"),
@@ -97,13 +97,13 @@ pub trait Nodes {
     /// #  .await
     /// #  .unwrap();
     /// // search for nodes ("*" is wildcard)
-    /// let nodes = dracoon.search_nodes("foo", None, None, None).await.unwrap();
+    /// let nodes = dracoon.nodes.search_nodes("foo", None, None, None).await.unwrap();
     ///
     /// // search for nodes in a parent
-    /// let nodes = dracoon.search_nodes("foo", Some(123), None, None).await.unwrap();
+    /// let nodes = dracoon.nodes.search_nodes("foo", Some(123), None, None).await.unwrap();
     ///
     /// // search for nodes in a parent with a depth level (-1 is full tree)
-    /// let nodes = dracoon.search_nodes("foo", Some(123), Some(1), None).await.unwrap();
+    /// let nodes = dracoon.nodes.search_nodes("foo", Some(123), Some(1), None).await.unwrap();
     ///
     /// // use filtering and sorting
     /// let params = ListAllParams::builder()
@@ -111,7 +111,7 @@ pub trait Nodes {
     ///                .with_filter(NodesSearchFilter::size_greater_equals(100))
     ///                .with_sort(NodesSearchSortBy::name(SortOrder::Desc))
     ///                .build();
-    /// let nodes = dracoon.search_nodes("foo", None, None, Some(params)).await.unwrap();
+    /// let nodes = dracoon.nodes.search_nodes("foo", None, None, Some(params)).await.unwrap();
     /// # }
     /// ```
     async fn search_nodes(
@@ -136,7 +136,7 @@ pub trait Nodes {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let node = dracoon.get_node(123).await.unwrap();
+    /// let node = dracoon.nodes.get_node(123).await.unwrap();
     /// # }
     /// ```
     async fn get_node(&self, node_id: u64) -> Result<Node, DracoonClientError>;
@@ -154,7 +154,7 @@ pub trait Nodes {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// dracoon.delete_node(123).await.unwrap();
+    /// dracoon.nodes.delete_node(123).await.unwrap();
     /// # }
     /// ```
     async fn delete_node(&self, node_id: u64) -> Result<(), DracoonClientError>;
@@ -173,7 +173,7 @@ pub trait Nodes {
     /// #  .await
     /// #  .unwrap();
     /// let node_ids = vec![123, 456];
-    /// dracoon.delete_nodes(node_ids.into()).await.unwrap();
+    /// dracoon.nodes.delete_nodes(node_ids.into()).await.unwrap();
     /// # }
     /// ```
 
@@ -193,7 +193,7 @@ pub trait Nodes {
     /// #  .await
     /// #  .unwrap();
     /// let node_ids = vec![123, 456];
-    /// dracoon.move_nodes(node_ids.into(), 789).await.unwrap();
+    /// dracoon.nodes.move_nodes(node_ids.into(), 789).await.unwrap();
     /// # }
     /// ```
     async fn move_nodes(
@@ -216,7 +216,7 @@ pub trait Nodes {
     /// #  .await
     /// #  .unwrap();
     /// let node_ids = vec![123, 456];
-    /// dracoon.copy_nodes(node_ids.into(), 789).await.unwrap();
+    /// dracoon.nodes.copy_nodes(node_ids.into(), 789).await.unwrap();
     /// # }
     /// ```
     async fn copy_nodes(
@@ -224,12 +224,16 @@ pub trait Nodes {
         req: TransferNodesRequest,
         target_parent_id: u64,
     ) -> Result<Node, DracoonClientError>;
+}
+
+#[async_trait]
+pub trait MissingFileKeys {
     /// Distributes missing file keys using the user keypair.
     /// Returns the total amount missing keys.
     /// If the total amount is larger than 100, more keys need distribution
     /// and the method should be called again.
     /// ```no_run
-    /// # use dco3::{Dracoon, OAuth2Flow, Nodes};
+    /// # use dco3::{Dracoon, OAuth2Flow, MissingFileKeys};
     /// # #[tokio::main]
     /// # async fn main() {
     /// # let dracoon = Dracoon::builder()
@@ -258,7 +262,6 @@ pub trait Nodes {
     /// let missing_user_keys = dracoon.distribute_missing_keys(None, None, Some(123)).await.unwrap();
     ///
     /// # }
-    ///
     async fn distribute_missing_keys(
         &self,
         room_id: Option<u64>,
@@ -287,7 +290,7 @@ pub trait Folders {
     ///                                .with_classification(1)
     ///                                .with_notes("My notes")
     ///                                .build();
-    /// let folder = dracoon.create_folder(folder).await.unwrap();
+    /// let folder = dracoon.nodes.create_folder(folder).await.unwrap();
     /// # }
     /// ```
     async fn create_folder(&self, req: CreateFolderRequest) -> Result<Node, DracoonClientError>;
@@ -309,7 +312,7 @@ pub trait Folders {
     ///                              .with_name("My Folder")
     ///                              .with_classification(2)
     ///                              .build();
-    /// dracoon.update_folder(123, update).await.unwrap();
+    /// dracoon.nodes.update_folder(123, update).await.unwrap();
     /// # }
     /// ```
     async fn update_folder(
@@ -354,7 +357,7 @@ pub trait Rooms {
     ///                              .with_parent_id(123)
     ///                              .with_classification(1)
     ///                              .build();
-    /// let room = dracoon.create_room(room).await.unwrap();
+    /// let room = dracoon.nodes.create_room(room).await.unwrap();
     /// # }
     /// ```
     async fn create_room(
@@ -378,7 +381,7 @@ pub trait Rooms {
     /// let room = UpdateRoomRequest::builder()
     ///                              .with_name("My new Room")
     ///                              .build();
-    /// let room = dracoon.update_room(123, room).await.unwrap();
+    /// let room = dracoon.nodes.update_room(123, room).await.unwrap();
     /// # }
     /// ```
     async fn update_room(
@@ -404,7 +407,7 @@ pub trait Rooms {
     ///                              .with_inherit_permissions(true)
     ///                              .with_recycle_bin_retention_period(30)
     ///                              .build();
-    /// let room = dracoon.config_room(123, room).await.unwrap();
+    /// let room = dracoon.nodes.config_room(123, room).await.unwrap();
     /// # }
     /// ```
     async fn config_room(
@@ -426,7 +429,7 @@ pub trait Rooms {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    ///  let policies = dracoon.get_room_policies(123).await.unwrap();
+    ///  let policies = dracoon.nodes.get_room_policies(123).await.unwrap();
     /// # }
     /// ```
     async fn get_room_policies(&self, room_id: u64) -> Result<RoomPolicies, DracoonClientError>;
@@ -448,7 +451,7 @@ pub trait Rooms {
     ///                            .with_default_expiration_period(60 * 60 * 24 * 30)
     ///                            .with_virus_protection_enabled(true)
     ///                            .build();
-    /// dracoon.update_room_policies(123, new_policies).await.unwrap();
+    /// dracoon.nodes.update_room_policies(123, new_policies).await.unwrap();
     /// # }
     /// ```
     //
@@ -475,7 +478,7 @@ pub trait Rooms {
     ///                           .try_with_data_room_rescue_key("Secret123")
     ///                           .unwrap()
     ///                           .build();
-    /// let room = dracoon.encrypt_room(123, encryption).await.unwrap();
+    /// let room = dracoon.nodes.encrypt_room(123, encryption).await.unwrap();
     /// # }
     /// ```
     async fn encrypt_room(
@@ -497,7 +500,7 @@ pub trait Rooms {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let groups = dracoon.get_room_groups(123, None).await.unwrap();
+    /// let groups = dracoon.nodes.get_room_groups(123, None).await.unwrap();
     /// # }
     /// ```
     async fn get_room_groups(
@@ -524,7 +527,7 @@ pub trait Rooms {
     ///
     /// // add a a list of updates
     /// let group_updates = vec![RoomGroupsAddBatchRequestItem::new(123, NodePermissions::new_with_read_permissions(), None)];
-    /// dracoon.update_room_groups(123, group_updates.into()).await.unwrap();
+    /// dracoon.nodes.update_room_groups(123, group_updates.into()).await.unwrap();
     /// # }
     /// ```
     async fn update_room_groups(
@@ -550,7 +553,7 @@ pub trait Rooms {
     /// #  .unwrap();
     /// // You can use a vec
     /// let group_ids = vec![1, 2, 3];
-    /// dracoon.delete_room_groups(123, group_ids.into()).await.unwrap();
+    /// dracoon.nodes.delete_room_groups(123, group_ids.into()).await.unwrap();
     /// # }
     /// ```
     async fn delete_room_groups(
@@ -575,7 +578,7 @@ pub trait Rooms {
     /// #  .await
     /// #  .unwrap();
 
-    /// let users = dracoon.get_room_users(123, None).await.unwrap();
+    /// let users = dracoon.nodes.get_room_users(123, None).await.unwrap();
     /// # }
     /// ```
     async fn get_room_users(
@@ -602,7 +605,7 @@ pub trait Rooms {
     ///
     /// // add a a list of updates
     /// let user_updates = vec![RoomUsersAddBatchRequestItem::new(123, NodePermissions::new_with_read_permissions())];
-    /// dracoon.update_room_users(123, user_updates.into()).await.unwrap();
+    /// dracoon.nodes.update_room_users(123, user_updates.into()).await.unwrap();
     /// # }
     /// ```
     async fn update_room_users(
@@ -627,7 +630,7 @@ pub trait Rooms {
     /// #  .unwrap();
     /// // You can use a vec
     /// let user_ids = vec![1, 2, 3];
-    /// dracoon.delete_room_users(123, user_ids.into()).await.unwrap();
+    /// dracoon.nodes.delete_room_users(123, user_ids.into()).await.unwrap();
     /// # }
     /// ```
     async fn delete_room_users(
@@ -663,7 +666,7 @@ pub trait Download {
     ///
     ///   let node_id = 123u64;
     ///
-    ///   let node = client.get_node(node_id).await.unwrap();
+    ///   let node = client.nodes.get_node(node_id).await.unwrap();
     ///
     ///   let mut writer = tokio::io::BufWriter::new(tokio::fs::File::create("test.txt").await.unwrap());
     ///
@@ -721,7 +724,7 @@ pub trait Upload<R: AsyncRead> {
     ///
     /// let parent_node_id = 123u64;
     ///
-    /// let parent_node = client.get_node(parent_node_id).await.unwrap();
+    /// let parent_node = client.nodes.get_node(parent_node_id).await.unwrap();
     ///
     /// let reader = tokio::io::BufReader::new(file);
     ///

--- a/src/nodes/models/mod.rs
+++ b/src/nodes/models/mod.rs
@@ -18,6 +18,7 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use crate::auth::DracoonClient;
 use crate::{
     auth::{errors::DracoonClientError, models::DracoonErrorResponse},
     models::{ObjectExpiration, Range, RangedItems},
@@ -33,6 +34,25 @@ use reqwest::{Response, StatusCode};
 use serde::{Deserialize, Serialize};
 
 use super::rooms::models::NodePermissionsBuilder;
+
+#[derive(Clone)]
+pub struct NodesEndpoint<S> {
+    client: Arc<DracoonClient<S>>,
+    state: std::marker::PhantomData<S>,
+}
+
+impl<S> NodesEndpoint<S> {
+    pub fn new(client: Arc<DracoonClient<S>>) -> Self {
+        Self {
+            client,
+            state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn client(&self) -> &Arc<DracoonClient<S>> {
+        &self.client
+    }
+}
 
 /// A callback function that is called after each chunk is processed (download)
 pub type DownloadProgressCallback = Box<dyn FnMut(u64, u64) + Send + Sync>;

--- a/src/nodes/nodes.rs
+++ b/src/nodes/nodes.rs
@@ -17,11 +17,11 @@ use crate::{
 
 use super::{
     models::{DeleteNodesRequest, Node, NodeList, TransferNodesRequest},
-    MissingKeysResponse, Nodes, UserFileKeySetBatchRequest,
+    MissingFileKeys, MissingKeysResponse, Nodes, NodesEndpoint, UserFileKeySetBatchRequest,
 };
 
 #[async_trait]
-impl Nodes for Dracoon<Connected> {
+impl Nodes for NodesEndpoint<Connected> {
     async fn get_nodes(
         &self,
         parent_id: Option<u64>,
@@ -31,7 +31,7 @@ impl Nodes for Dracoon<Connected> {
         let params = params.unwrap_or_default();
         let url_part = format!("/{DRACOON_API_PREFIX}/{NODES_BASE}");
 
-        let mut api_url = self.build_api_url(&url_part);
+        let mut api_url = self.client().build_api_url(&url_part);
 
         let filters = params.filter_to_string();
         let sorts = params.sort_to_string();
@@ -47,10 +47,13 @@ impl Nodes for Dracoon<Connected> {
             .finish();
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -67,7 +70,7 @@ impl Nodes for Dracoon<Connected> {
             DracoonClientError::InvalidPath(path.to_string())
         })?;
 
-        let mut api_url = self.build_api_url(&url_part);
+        let mut api_url = self.client().build_api_url(&url_part);
 
         api_url
             .query_pairs_mut()
@@ -77,10 +80,13 @@ impl Nodes for Dracoon<Connected> {
             .finish();
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -98,13 +104,16 @@ impl Nodes for Dracoon<Connected> {
     async fn get_node(&self, node_id: u64) -> Result<Node, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{node_id}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -122,7 +131,7 @@ impl Nodes for Dracoon<Connected> {
         let params = params.unwrap_or_default();
         let url_part = format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{NODES_SEARCH}");
 
-        let mut api_url = self.build_api_url(&url_part);
+        let mut api_url = self.client().build_api_url(&url_part);
 
         let filters = params.filter_to_string();
         let sorts = params.sort_to_string();
@@ -139,10 +148,13 @@ impl Nodes for Dracoon<Connected> {
             .finish();
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -153,13 +165,16 @@ impl Nodes for Dracoon<Connected> {
     async fn delete_node(&self, node_id: u64) -> Result<(), DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{node_id}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -176,13 +191,16 @@ impl Nodes for Dracoon<Connected> {
     async fn delete_nodes(&self, req: DeleteNodesRequest) -> Result<(), DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{NODES_BASE}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&req)
             .send()
@@ -205,13 +223,16 @@ impl Nodes for Dracoon<Connected> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{target_parent_id}/{NODES_MOVE}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&req)
             .send()
@@ -228,13 +249,16 @@ impl Nodes for Dracoon<Connected> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{target_parent_id}/{NODES_COPY}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&req)
             .send()
@@ -242,7 +266,10 @@ impl Nodes for Dracoon<Connected> {
 
         Node::from_response(response).await
     }
+}
 
+#[async_trait]
+impl MissingFileKeys for Dracoon<Connected> {
     async fn distribute_missing_keys(
         &self,
         room_id: Option<u64>,
@@ -273,7 +300,7 @@ impl Nodes for Dracoon<Connected> {
 }
 
 #[async_trait]
-trait NodesMissingFileKeysInternal {
+trait MissingFileKeysInternal {
     async fn get_missing_file_keys(
         &self,
         room_id: Option<u64>,
@@ -289,7 +316,7 @@ trait NodesMissingFileKeysInternal {
 }
 
 #[async_trait]
-impl NodesMissingFileKeysInternal for Dracoon<Connected> {
+impl MissingFileKeysInternal for Dracoon<Connected> {
     async fn get_missing_file_keys(
         &self,
         room_id: Option<u64>,
@@ -355,6 +382,7 @@ impl NodesMissingFileKeysInternal for Dracoon<Connected> {
 }
 
 type ParsedPath = (String, String, u64);
+
 pub fn parse_node_path(path: &str) -> Result<ParsedPath, DracoonClientError> {
     if path == "/" {
         return Ok((String::from("/"), String::new(), 0));

--- a/src/nodes/rooms/mod.rs
+++ b/src/nodes/rooms/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     },
     models::ListAllParams,
     utils::FromResponse,
-    Dracoon,
 };
 
 use self::models::{
@@ -18,24 +17,27 @@ use self::models::{
     RoomUserList, RoomUsersAddBatchRequest, RoomUsersDeleteBatchRequest, UpdateRoomRequest,
 };
 
-use super::{models::Node, Rooms};
+use super::{models::Node, NodesEndpoint, Rooms};
 
 pub mod models;
 
 #[async_trait]
-impl Rooms for Dracoon<Connected> {
+impl Rooms for NodesEndpoint<Connected> {
     async fn create_room(
         &self,
         create_room_req: CreateRoomRequest,
     ) -> Result<Node, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&create_room_req)
             .send()
@@ -49,13 +51,16 @@ impl Rooms for Dracoon<Connected> {
         update_room_req: UpdateRoomRequest,
     ) -> Result<Node, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&update_room_req)
             .send()
@@ -70,13 +75,16 @@ impl Rooms for Dracoon<Connected> {
     ) -> Result<Node, DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}/{ROOMS_CONFIG}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&config_room_req)
             .send()
@@ -87,13 +95,16 @@ impl Rooms for Dracoon<Connected> {
     async fn get_room_policies(&self, room_id: u64) -> Result<RoomPolicies, DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}/{ROOMS_POLICIES}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -106,13 +117,16 @@ impl Rooms for Dracoon<Connected> {
     ) -> Result<(), DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}/{ROOMS_POLICIES}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&policy_room_req)
             .send()
@@ -131,13 +145,16 @@ impl Rooms for Dracoon<Connected> {
     ) -> Result<Node, DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}/{ROOMS_ENCRYPT}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&encrypt_room_req)
             .send()
@@ -152,7 +169,7 @@ impl Rooms for Dracoon<Connected> {
     ) -> Result<RoomGroupList, DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}/{ROOMS_GROUPS}");
-        let mut api_url = self.build_api_url(&url_part);
+        let mut api_url = self.client().build_api_url(&url_part);
 
         let params = params.unwrap_or_default();
         let filters = params.filter_to_string();
@@ -167,10 +184,13 @@ impl Rooms for Dracoon<Connected> {
             .finish();
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -183,13 +203,16 @@ impl Rooms for Dracoon<Connected> {
     ) -> Result<(), DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}/{ROOMS_GROUPS}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&room_groups_update_req)
             .send()
@@ -208,13 +231,16 @@ impl Rooms for Dracoon<Connected> {
     ) -> Result<(), DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}/{ROOMS_GROUPS}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&room_groups_del_req)
             .send()
@@ -233,7 +259,7 @@ impl Rooms for Dracoon<Connected> {
     ) -> Result<RoomUserList, DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}/{ROOMS_USERS}");
-        let mut api_url = self.build_api_url(&url_part);
+        let mut api_url = self.client().build_api_url(&url_part);
 
         let params = params.unwrap_or_default();
 
@@ -249,10 +275,13 @@ impl Rooms for Dracoon<Connected> {
             .finish();
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -265,13 +294,16 @@ impl Rooms for Dracoon<Connected> {
     ) -> Result<(), DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}/{ROOMS_USERS}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&room_users_update_req)
             .send()
@@ -290,13 +322,16 @@ impl Rooms for Dracoon<Connected> {
     ) -> Result<(), DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{NODES_BASE}/{ROOMS_BASE}/{room_id}/{ROOMS_USERS}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&room_users_del_req)
             .send()

--- a/src/provisioning/models.rs
+++ b/src/provisioning/models.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dco3_derive::FromResponse;
@@ -5,11 +7,30 @@ use reqwest::Response;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    auth::DracoonErrorResponse,
+    auth::{DracoonClient, DracoonErrorResponse},
     user::UserAuthData,
     utils::{parse_body, FromResponse},
     DracoonClientError, KeyValueEntry, RangedItems,
 };
+
+#[derive(Clone)]
+pub struct ProvisioningEndpoint<S> {
+    client: Arc<DracoonClient<S>>,
+    state: std::marker::PhantomData<S>,
+}
+
+impl<S> ProvisioningEndpoint<S> {
+    pub fn new(client: Arc<DracoonClient<S>>) -> Self {
+        Self {
+            client,
+            state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn client(&self) -> &Arc<DracoonClient<S>> {
+        &self.client
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct CustomerAttributes {

--- a/src/provisioning/models.rs
+++ b/src/provisioning/models.rs
@@ -116,7 +116,7 @@ impl FirstAdminUser {
         email: impl Into<String>,
         receiver_language: Option<String>,
     ) -> FirstAdminUser {
-        let auth_data = UserAuthData::new_basic(None);
+        let auth_data = UserAuthData::new_basic(None, None);
 
         FirstAdminUser {
             first_name: first_name.into(),

--- a/src/public/mod.rs
+++ b/src/public/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         PUBLIC_VERSION,
     },
     utils::FromResponse,
-    Dracoon, DracoonClientError,
+    DracoonClientError,
 };
 
 pub use self::models::*;
@@ -21,7 +21,7 @@ pub trait Public {
 }
 
 #[async_trait]
-impl Public for Dracoon<Connected> {
+impl Public for PublicEndpoint<Connected> {
     /// Get software version information for the DRACOON backend (API).
     /// ```no_run
     /// # use dco3::{Dracoon, auth::OAuth2Flow, Public};
@@ -37,7 +37,7 @@ impl Public for Dracoon<Connected> {
     /// #  .await
     /// #  .unwrap();
     ///
-    /// let software_version = dracoon.get_software_version().await.unwrap();
+    /// let software_version = dracoon.public.get_software_version().await.unwrap();
     ///
     /// # }
     ///
@@ -45,10 +45,10 @@ impl Public for Dracoon<Connected> {
         let url_part =
             format!("{DRACOON_API_PREFIX}/{PUBLIC_BASE}/{PUBLIC_SOFTWARE_BASE}/{PUBLIC_VERSION}");
 
-        let url = self.build_api_url(&url_part);
+        let url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(url)
             .header(header::CONTENT_TYPE, "application/json")
@@ -73,17 +73,17 @@ impl Public for Dracoon<Connected> {
     /// #  .await
     /// #  .unwrap();
     ///
-    /// let system_info = dracoon.get_system_info().await.unwrap();
+    /// let system_info = dracoon.public.get_system_info().await.unwrap();
     ///
     /// # }
     async fn get_system_info(&self) -> Result<SystemInfo, DracoonClientError> {
         let url_part =
             format!("{DRACOON_API_PREFIX}/{PUBLIC_BASE}/{PUBLIC_SYSTEM_BASE}/{PUBLIC_INFO}");
 
-        let url = self.build_api_url(&url_part);
+        let url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(url)
             .header(header::CONTENT_TYPE, "application/json")
@@ -96,9 +96,10 @@ impl Public for Dracoon<Connected> {
 
 #[cfg(test)]
 mod tests {
+
     use chrono::Datelike;
 
-    use crate::{public::Public, tests::dracoon::get_connected_client};
+    use crate::{tests::dracoon::get_connected_client, Public};
 
     #[tokio::test]
     async fn test_get_system_info() {
@@ -114,7 +115,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let system_info = client.get_system_info().await.unwrap();
+        let system_info = client.public.get_system_info().await.unwrap();
 
         system_info_mock.assert();
 
@@ -139,7 +140,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let software_version = client.get_software_version().await.unwrap();
+        let software_version = client.public.get_software_version().await.unwrap();
 
         software_version_mock.assert();
 

--- a/src/public/models.rs
+++ b/src/public/models.rs
@@ -1,6 +1,29 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use dco3_derive::FromResponse;
 use serde::Deserialize;
+
+use crate::auth::DracoonClient;
+
+#[derive(Clone)]
+pub struct PublicEndpoint<S> {
+    client: Arc<DracoonClient<S>>,
+    state: std::marker::PhantomData<S>,
+}
+
+impl <S> PublicEndpoint<S> {
+    pub fn new(client: Arc<DracoonClient<S>>) -> Self {
+        Self {
+            client,
+            state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn client(&self) -> &Arc<DracoonClient<S>> {
+        &self.client
+    }
+}
 
 #[derive(Debug, Deserialize, FromResponse)]
 #[serde(rename_all = "camelCase")]

--- a/src/public/models.rs
+++ b/src/public/models.rs
@@ -12,7 +12,7 @@ pub struct PublicEndpoint<S> {
     state: std::marker::PhantomData<S>,
 }
 
-impl <S> PublicEndpoint<S> {
+impl<S> PublicEndpoint<S> {
     pub fn new(client: Arc<DracoonClient<S>>) -> Self {
         Self {
             client,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -3,6 +3,9 @@ use async_trait::async_trait;
 use crate::DracoonClientError;
 
 mod keypair;
+mod models;
+
+pub use models::SettingsEndpoint;
 
 #[async_trait]
 /// This trait currently implements distributing missing keys uing the system rescue key.
@@ -24,21 +27,21 @@ pub trait RescueKeyPair {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let mut missing_keys = dracoon.distribute_missing_keys("rescue_key_secret", None, None, None).await.unwrap();
+    /// let mut missing_keys = dracoon.settings.distribute_missing_keys("rescue_key_secret", None, None, None).await.unwrap();
     ///
     /// while missing_keys > 100 {
     /// // loop until no more keys need distribution
-    /// missing_keys = dracoon.distribute_missing_keys("rescue_key_secret", None, None, None).await.unwrap();
+    /// missing_keys = dracoon.settings.distribute_missing_keys("rescue_key_secret", None, None, None).await.unwrap();
     /// }
     ///
     /// // distribute missing keys for a specific room
-    /// let missing_room_keys = dracoon.distribute_missing_keys("rescue_key_secret", Some(123), None, None).await.unwrap();
+    /// let missing_room_keys = dracoon.settings.distribute_missing_keys("rescue_key_secret", Some(123), None, None).await.unwrap();
     ///
     /// // distribute missing keys for a specific file
-    /// let missing_file_keys = dracoon.distribute_missing_keys("rescue_key_secret", None, Some(123), None).await.unwrap();
+    /// let missing_file_keys = dracoon.settings.distribute_missing_keys("rescue_key_secret", None, Some(123), None).await.unwrap();
     ///
     /// // distribute missing keys for a specific user
-    /// let missing_user_keys = dracoon.distribute_missing_keys("rescue_key_secret", None, None, Some(123)).await.unwrap();
+    /// let missing_user_keys = dracoon.settings.distribute_missing_keys("rescue_key_secret", None, None, Some(123)).await.unwrap();
     ///
     /// # }
     ///

--- a/src/settings/models.rs
+++ b/src/settings/models.rs
@@ -1,20 +1,14 @@
-mod download;
-mod upload;
-
 use std::sync::Arc;
-
-pub use download::*;
-pub use upload::*;
 
 use crate::auth::DracoonClient;
 
 #[derive(Clone)]
-pub struct SharesEndpoint<S> {
+pub struct SettingsEndpoint<S> {
     client: Arc<DracoonClient<S>>,
     state: std::marker::PhantomData<S>,
 }
 
-impl<S> SharesEndpoint<S> {
+impl<S> SettingsEndpoint<S> {
     pub fn new(client: Arc<DracoonClient<S>>) -> Self {
         Self {
             client,

--- a/src/shares/download.rs
+++ b/src/shares/download.rs
@@ -4,13 +4,13 @@ use reqwest::header;
 use crate::constants::{DRACOON_API_PREFIX, SHARES_BASE, SHARES_DOWNLOAD, SHARES_EMAIL};
 use crate::models::ListAllParams;
 use crate::utils::FromResponse;
-use crate::{auth::Connected, Dracoon, DracoonClientError};
+use crate::{auth::Connected, DracoonClientError};
 
 use super::models::*;
 use super::DownloadShares;
 
 #[async_trait]
-impl DownloadShares for Dracoon<Connected> {
+impl DownloadShares for SharesEndpoint<Connected> {
     async fn get_download_shares(
         &self,
         params: Option<ListAllParams>,
@@ -18,7 +18,7 @@ impl DownloadShares for Dracoon<Connected> {
         let params = params.unwrap_or_default();
         let url_part = format!("{DRACOON_API_PREFIX}/{SHARES_BASE}/{SHARES_DOWNLOAD}");
 
-        let mut api_url = self.build_api_url(&url_part);
+        let mut api_url = self.client().build_api_url(&url_part);
 
         let filters = params.filter_to_string();
         let sorts = params.sort_to_string();
@@ -32,10 +32,13 @@ impl DownloadShares for Dracoon<Connected> {
             .finish();
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -49,13 +52,16 @@ impl DownloadShares for Dracoon<Connected> {
     ) -> Result<(), DracoonClientError> {
         let url_part = format!("{DRACOON_API_PREFIX}/{SHARES_BASE}/{SHARES_DOWNLOAD}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&update)
             .send()
@@ -76,13 +82,16 @@ impl DownloadShares for Dracoon<Connected> {
     ) -> Result<(), DracoonClientError> {
         let url_part = format!("{DRACOON_API_PREFIX}/{SHARES_BASE}/{SHARES_DOWNLOAD}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&delete)
             .send()
@@ -103,13 +112,16 @@ impl DownloadShares for Dracoon<Connected> {
     ) -> Result<DownloadShare, DracoonClientError> {
         let url_part = format!("{DRACOON_API_PREFIX}/{SHARES_BASE}/{SHARES_DOWNLOAD}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&create)
             .send()
@@ -127,13 +139,16 @@ impl DownloadShares for Dracoon<Connected> {
             id = download_share_id
         );
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -151,13 +166,16 @@ impl DownloadShares for Dracoon<Connected> {
             id = download_share_id
         );
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&update)
             .send()
@@ -175,13 +193,16 @@ impl DownloadShares for Dracoon<Connected> {
             id = download_share_id
         );
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -205,13 +226,16 @@ impl DownloadShares for Dracoon<Connected> {
             id = download_share_id
         );
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&email)
             .send()

--- a/src/shares/mod.rs
+++ b/src/shares/mod.rs
@@ -32,7 +32,7 @@ pub trait DownloadShares {
     ///     .with_sort(DownloadSharesSortBy::name(SortOrder::Desc))
     ///     .build();
     /// // pass None if you don't want to use any params
-    /// let shares = dracoon.get_download_shares(Some(params)).await.unwrap();
+    /// let shares = dracoon.shares.get_download_shares(Some(params)).await.unwrap();
     ///
     /// # }
     /// ```
@@ -58,7 +58,7 @@ pub trait DownloadShares {
     /// let update = UpdateDownloadSharesBulkRequest::builder(ids)
     ///     .with_show_creator_name(true)
     ///     .build();
-    /// dracoon.update_download_shares(update).await.unwrap();
+    /// dracoon.shares.update_download_shares(update).await.unwrap();
     /// # }
     /// ```
     async fn update_download_shares(
@@ -80,11 +80,11 @@ pub trait DownloadShares {
     /// #  .await
     /// #  .unwrap();
     /// let ids = vec![1, 2, 3];
-    /// dracoon.delete_download_shares(ids.into()).await.unwrap();
+    /// dracoon.shares.delete_download_shares(ids.into()).await.unwrap();
     /// // you can also use the DeleteDownloadSharesRequest::new() method
     /// let ids = vec![1, 2, 3];
     /// let delete = DeleteDownloadSharesRequest::new(ids);
-    /// dracoon.delete_download_shares(delete).await.unwrap();
+    /// dracoon.shares.delete_download_shares(delete).await.unwrap();
     /// # }
     /// ```
     async fn delete_download_shares(
@@ -108,7 +108,7 @@ pub trait DownloadShares {
     /// let share = CreateDownloadShareRequest::builder(1)
     ///     .with_name("test")
     ///     .build();
-    /// dracoon.create_download_share(share).await.unwrap();
+    /// dracoon.shares.create_download_share(share).await.unwrap();
     /// # }
     /// ```
     async fn create_download_share(
@@ -129,7 +129,7 @@ pub trait DownloadShares {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let file_request = dracoon.get_download_share(1).await.unwrap();
+    /// let file_request = dracoon.shares.get_download_share(1).await.unwrap();
     /// # }
     /// ```
     async fn get_download_share(&self, share_id: u64) -> Result<DownloadShare, DracoonClientError>;
@@ -150,7 +150,7 @@ pub trait DownloadShares {
     /// let update = UpdateDownloadShareRequest::builder()
     ///    .with_name("test")
     ///    .build();
-    /// let file_request = dracoon.update_download_share(123, update).await.unwrap();
+    /// let file_request = dracoon.shares.update_download_share(123, update).await.unwrap();
     /// # }
     /// ```
     async fn update_download_share(
@@ -172,7 +172,7 @@ pub trait DownloadShares {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// dracoon.delete_upload_share(1).await.unwrap();
+    /// dracoon.shares.delete_upload_share(1).await.unwrap();
     /// # }
     /// ```
     async fn delete_download_share(&self, share_id: u64) -> Result<(), DracoonClientError>;
@@ -192,7 +192,7 @@ pub trait DownloadShares {
     /// #  .unwrap();
     /// let recipients = vec!["test@test.foo".to_string(), "test2@test.foo".to_string()];
     /// let send_mail = DownloadShareLinkEmail::new("Test email", recipients, None);
-    /// dracoon.send_download_share_email(123, send_mail).await.unwrap();
+    /// dracoon.shares.send_download_share_email(123, send_mail).await.unwrap();
     /// # }
     /// ```
     async fn send_download_share_email(
@@ -225,7 +225,7 @@ pub trait UploadShares {
     ///     .with_sort(UploadSharesSortBy::name(SortOrder::Desc))
     ///     .build();
     /// // pass None if you don't want to use any params
-    /// let file_requests = dracoon.get_upload_shares(Some(params)).await.unwrap();
+    /// let file_requests = dracoon.shares.get_upload_shares(Some(params)).await.unwrap();
     ///
     /// # }
     /// ```
@@ -252,7 +252,7 @@ pub trait UploadShares {
     ///     .with_max_size(1024)
     ///     .with_reset_max_size(true)
     ///     .build();
-    /// dracoon.update_upload_shares(update).await.unwrap();
+    /// dracoon.shares.update_upload_shares(update).await.unwrap();
     /// # }
     /// ```
     async fn update_upload_shares(
@@ -274,11 +274,11 @@ pub trait UploadShares {
     /// #  .await
     /// #  .unwrap();
     /// let ids = vec![1, 2, 3];
-    /// dracoon.delete_upload_shares(ids.into()).await.unwrap();
+    /// dracoon.shares.delete_upload_shares(ids.into()).await.unwrap();
     /// // you can also use the DeleteUploadSharesRequest::new() method
     /// let ids = vec![1, 2, 3];
     /// let delete = DeleteUploadSharesRequest::new(ids);
-    /// dracoon.delete_upload_shares(delete).await.unwrap();
+    /// dracoon.shares.delete_upload_shares(delete).await.unwrap();
     /// # }
     /// ```
     async fn delete_upload_shares(
@@ -302,7 +302,7 @@ pub trait UploadShares {
     /// let share = CreateUploadShareRequest::builder(1)
     ///     .with_name("test")
     ///     .build();
-    /// dracoon.create_upload_share(share).await.unwrap();
+    /// dracoon.shares.create_upload_share(share).await.unwrap();
     /// # }
     /// ```
     async fn create_upload_share(
@@ -323,7 +323,7 @@ pub trait UploadShares {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let file_request = dracoon.get_upload_share(1).await.unwrap();
+    /// let file_request = dracoon.shares.get_upload_share(1).await.unwrap();
     /// # }
     /// ```
     async fn get_upload_share(
@@ -347,7 +347,7 @@ pub trait UploadShares {
     /// let update = UpdateUploadShareRequest::builder()
     ///    .with_name("test")
     ///   .build();
-    /// let file_request = dracoon.update_upload_share(123, update).await.unwrap();
+    /// let file_request = dracoon.shares.update_upload_share(123, update).await.unwrap();
     /// # }
     /// ```
     async fn update_upload_share(
@@ -369,7 +369,7 @@ pub trait UploadShares {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// dracoon.delete_upload_share(1).await.unwrap();
+    /// dracoon.shares.delete_upload_share(1).await.unwrap();
     /// # }
     /// ```
     async fn delete_upload_share(&self, upload_share_id: u64) -> Result<(), DracoonClientError>;
@@ -389,7 +389,7 @@ pub trait UploadShares {
     /// #  .unwrap();
     /// let recipients = vec!["test@test.foo".to_string(), "test2@test.foo".to_string()];
     /// let send_mail = UploadShareLinkEmail::new("Test email", recipients, None);
-    /// dracoon.send_upload_share_email(123, send_mail).await.unwrap();
+    /// dracoon.shares.send_upload_share_email(123, send_mail).await.unwrap();
     /// # }
     /// ```
     async fn send_upload_share_email(

--- a/src/shares/models/mod.rs
+++ b/src/shares/models/mod.rs
@@ -1,5 +1,29 @@
 mod download;
 mod upload;
 
+use std::sync::Arc;
+
 pub use download::*;
 pub use upload::*;
+
+use crate::auth::DracoonClient;
+
+
+#[derive(Clone)]
+pub struct SharesEndpoint<S> {
+    client: Arc<DracoonClient<S>>,
+    state: std::marker::PhantomData<S>,
+}
+
+impl <S> SharesEndpoint<S> {
+    pub fn new(client: Arc<DracoonClient<S>>) -> Self {
+        Self {
+            client,
+            state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn client(&self) -> &Arc<DracoonClient<S>> {
+        &self.client
+    }
+}

--- a/src/shares/upload.rs
+++ b/src/shares/upload.rs
@@ -4,13 +4,13 @@ use reqwest::header;
 use crate::constants::{DRACOON_API_PREFIX, SHARES_BASE, SHARES_EMAIL, SHARES_UPLOAD};
 use crate::models::ListAllParams;
 use crate::utils::FromResponse;
-use crate::{auth::Connected, Dracoon, DracoonClientError};
+use crate::{auth::Connected, DracoonClientError};
 
 use super::models::*;
 use super::UploadShares;
 
 #[async_trait]
-impl UploadShares for Dracoon<Connected> {
+impl UploadShares for SharesEndpoint<Connected> {
     async fn get_upload_shares(
         &self,
         params: Option<ListAllParams>,
@@ -18,7 +18,7 @@ impl UploadShares for Dracoon<Connected> {
         let params = params.unwrap_or_default();
         let url_part = format!("{DRACOON_API_PREFIX}/{SHARES_BASE}/{SHARES_UPLOAD}");
 
-        let mut api_url = self.build_api_url(&url_part);
+        let mut api_url = self.client().build_api_url(&url_part);
 
         let filters = params.filter_to_string();
         let sorts = params.sort_to_string();
@@ -32,10 +32,13 @@ impl UploadShares for Dracoon<Connected> {
             .finish();
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -49,13 +52,16 @@ impl UploadShares for Dracoon<Connected> {
     ) -> Result<(), DracoonClientError> {
         let url_part = format!("{DRACOON_API_PREFIX}/{SHARES_BASE}/{SHARES_UPLOAD}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&update)
             .send()
@@ -76,13 +82,16 @@ impl UploadShares for Dracoon<Connected> {
     ) -> Result<(), DracoonClientError> {
         let url_part = format!("{DRACOON_API_PREFIX}/{SHARES_BASE}/{SHARES_UPLOAD}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&delete)
             .send()
@@ -103,13 +112,16 @@ impl UploadShares for Dracoon<Connected> {
     ) -> Result<UploadShare, DracoonClientError> {
         let url_part = format!("{DRACOON_API_PREFIX}/{SHARES_BASE}/{SHARES_UPLOAD}");
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&create)
             .send()
@@ -127,13 +139,16 @@ impl UploadShares for Dracoon<Connected> {
             id = upload_share_id
         );
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -151,13 +166,16 @@ impl UploadShares for Dracoon<Connected> {
             id = upload_share_id
         );
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&update)
             .send()
@@ -172,13 +190,16 @@ impl UploadShares for Dracoon<Connected> {
             id = upload_share_id
         );
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -202,13 +223,16 @@ impl UploadShares for Dracoon<Connected> {
             id = upload_share_id
         );
 
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&email)
             .send()

--- a/src/system/auth/models.rs
+++ b/src/system/auth/models.rs
@@ -1,13 +1,34 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use dco3_derive::FromResponse;
 use reqwest::Response;
 use serde::Deserialize;
 
 use crate::{
-    auth::DracoonErrorResponse,
+    auth::{DracoonClient, DracoonErrorResponse},
     utils::{parse_body, FromResponse},
     DracoonClientError,
 };
+
+#[derive(Clone)]
+pub struct SystemAuthEndpoint<S> {
+    client: Arc<DracoonClient<S>>,
+    state: std::marker::PhantomData<S>,
+}
+
+impl <S> SystemAuthEndpoint<S> {
+    pub fn new(client: Arc<DracoonClient<S>>) -> Self {
+        Self {
+            client,
+            state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn client(&self) -> &Arc<DracoonClient<S>> {
+        &self.client
+    }
+}
 
 #[derive(Debug, Deserialize, Clone, FromResponse)]
 #[serde(rename_all = "camelCase")]

--- a/src/system/auth/models.rs
+++ b/src/system/auth/models.rs
@@ -17,7 +17,7 @@ pub struct SystemAuthEndpoint<S> {
     state: std::marker::PhantomData<S>,
 }
 
-impl <S> SystemAuthEndpoint<S> {
+impl<S> SystemAuthEndpoint<S> {
     pub fn new(client: Arc<DracoonClient<S>>) -> Self {
         Self {
             client,

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -1,1 +1,20 @@
+use std::sync::Arc;
+
+use crate::auth::DracoonClient;
+
+use self::auth::SystemAuthEndpoint;
+
 mod auth;
+
+#[derive(Clone)]
+pub struct SystemEndpoint<S> {
+    pub auth: SystemAuthEndpoint<S>,
+}
+
+impl<S> SystemEndpoint<S> {
+    pub fn new(client: Arc<DracoonClient<S>>) -> Self {
+        Self {
+            auth: SystemAuthEndpoint::new(client),
+        }
+    }
+}

--- a/src/tests/groups.rs
+++ b/src/tests/groups.rs
@@ -23,7 +23,7 @@ mod tests {
             .with_body(groups_res)
             .create();
 
-        let groups = dracoon.get_groups(None).await.unwrap();
+        let groups = dracoon.groups.get_groups(None).await.unwrap();
         let group = groups.items.first().unwrap();
 
         groups_mock.assert();
@@ -122,7 +122,7 @@ mod tests {
             .with_filter(GroupsFilter::Name(FilterOperator::Eq, "string".to_string()))
             .build();
 
-        let groups = dracoon.get_groups(Some(params)).await.unwrap();
+        let groups = dracoon.groups.get_groups(Some(params)).await.unwrap();
 
         groups_mock.assert();
     }
@@ -145,7 +145,7 @@ mod tests {
             .with_sort(GroupsSortBy::Name(SortOrder::Asc))
             .build();
 
-        let groups = dracoon.get_groups(Some(params)).await.unwrap();
+        let groups = dracoon.groups.get_groups(Some(params)).await.unwrap();
 
         groups_mock.assert();
     }
@@ -166,7 +166,7 @@ mod tests {
 
         let params = ListAllParams::default();
 
-        let groups = dracoon.get_groups(Some(params)).await.unwrap();
+        let groups = dracoon.groups.get_groups(Some(params)).await.unwrap();
 
         groups_mock.assert();
     }
@@ -187,7 +187,7 @@ mod tests {
 
         let params = ListAllParams::builder().with_limit(10).build();
 
-        let groups = dracoon.get_groups(Some(params)).await.unwrap();
+        let groups = dracoon.groups.get_groups(Some(params)).await.unwrap();
 
         groups_mock.assert();
     }
@@ -206,7 +206,7 @@ mod tests {
             .with_body(groups_res)
             .create();
 
-        let group = dracoon.get_group(123).await.unwrap();
+        let group = dracoon.groups.get_group(123).await.unwrap();
 
         group_mock.assert();
 
@@ -253,7 +253,7 @@ mod tests {
 
         let group = CreateGroupRequest::new("string", None);
 
-        let group = dracoon.create_group(group).await.unwrap();
+        let group = dracoon.groups.create_group(group).await.unwrap();
 
         group_mock.assert();
 
@@ -300,7 +300,7 @@ mod tests {
 
         let update = UpdateGroupRequest::name("string");
 
-        let group = dracoon.update_group(123, update).await.unwrap();
+        let group = dracoon.groups.update_group(123, update).await.unwrap();
 
         group_mock.assert();
 
@@ -341,7 +341,7 @@ mod tests {
             .with_status(204)
             .create();
 
-        dracoon.delete_group(123).await.unwrap();
+        dracoon.groups.delete_group(123).await.unwrap();
 
         groups_mock.assert();
     }

--- a/src/tests/nodes.rs
+++ b/src/tests/nodes.rs
@@ -87,7 +87,7 @@ pub mod tests {
             .with_body(nodes_res)
             .create();
 
-        let nodes = dracoon.get_nodes(None, None, None).await.unwrap();
+        let nodes = dracoon.nodes.get_nodes(None, None, None).await.unwrap();
 
         nodes_mock.assert();
 
@@ -113,7 +113,11 @@ pub mod tests {
             .with_body(nodes_res)
             .create();
 
-        let _nodes = dracoon.get_nodes(Some(123), None, None).await.unwrap();
+        let _nodes = dracoon
+            .nodes
+            .get_nodes(Some(123), None, None)
+            .await
+            .unwrap();
 
         nodes_mock.assert();
     }
@@ -134,7 +138,11 @@ pub mod tests {
             .create();
         let params = ListAllParams::builder().with_offset(500).build();
 
-        let _nodes = dracoon.get_nodes(None, None, Some(params)).await.unwrap();
+        let _nodes = dracoon
+            .nodes
+            .get_nodes(None, None, Some(params))
+            .await
+            .unwrap();
 
         nodes_mock.assert();
     }
@@ -156,7 +164,11 @@ pub mod tests {
 
         let params = ListAllParams::builder().with_limit(100).build();
 
-        let _nodes = dracoon.get_nodes(None, None, Some(params)).await.unwrap();
+        let _nodes = dracoon
+            .nodes
+            .get_nodes(None, None, Some(params))
+            .await
+            .unwrap();
 
         nodes_mock.assert();
     }
@@ -180,7 +192,11 @@ pub mod tests {
             .with_filter(NodesFilter::name_equals("test"))
             .build();
 
-        let _nodes = dracoon.get_nodes(None, None, Some(params)).await.unwrap();
+        let _nodes = dracoon
+            .nodes
+            .get_nodes(None, None, Some(params))
+            .await
+            .unwrap();
 
         nodes_mock.assert();
     }
@@ -204,7 +220,11 @@ pub mod tests {
             .with_sort(NodesSortBy::Name(SortOrder::Asc))
             .build();
 
-        let _nodes = dracoon.get_nodes(None, None, Some(params)).await.unwrap();
+        let _nodes = dracoon
+            .nodes
+            .get_nodes(None, None, Some(params))
+            .await
+            .unwrap();
 
         nodes_mock.assert();
     }
@@ -226,7 +246,7 @@ pub mod tests {
             .with_body(nodes_res)
             .create();
 
-        let node = dracoon.get_node_from_path(path).await.unwrap();
+        let node = dracoon.nodes.get_node_from_path(path).await.unwrap();
 
         nodes_mock.assert();
 
@@ -254,7 +274,7 @@ pub mod tests {
             .with_body(nodes_res)
             .create();
 
-        let node = dracoon.get_node_from_path(path).await.unwrap();
+        let node = dracoon.nodes.get_node_from_path(path).await.unwrap();
 
         nodes_mock.assert();
 
@@ -276,7 +296,7 @@ pub mod tests {
             .with_body(node_res)
             .create();
 
-        let node = dracoon.get_node(123).await.unwrap();
+        let node = dracoon.nodes.get_node(123).await.unwrap();
 
         assert_node(&node);
     }
@@ -293,7 +313,7 @@ pub mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        dracoon.delete_node(123).await.unwrap();
+        dracoon.nodes.delete_node(123).await.unwrap();
 
         node_mock.assert();
     }
@@ -312,7 +332,7 @@ pub mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        dracoon.delete_nodes(node_ids.into()).await.unwrap();
+        dracoon.nodes.delete_nodes(node_ids.into()).await.unwrap();
 
         node_mock.assert();
     }
@@ -334,7 +354,11 @@ pub mod tests {
             .with_body(node_res)
             .create();
 
-        let target_node = dracoon.copy_nodes(node_ids.into(), 123).await.unwrap();
+        let target_node = dracoon
+            .nodes
+            .copy_nodes(node_ids.into(), 123)
+            .await
+            .unwrap();
 
         copy_mock.assert();
 
@@ -358,7 +382,11 @@ pub mod tests {
             .with_body(node_res)
             .create();
 
-        let target_node = dracoon.move_nodes(node_ids.into(), 123).await.unwrap();
+        let target_node = dracoon
+            .nodes
+            .move_nodes(node_ids.into(), 123)
+            .await
+            .unwrap();
 
         move_mock.assert();
 
@@ -381,6 +409,7 @@ pub mod tests {
             .create();
 
         let nodes = dracoon
+            .nodes
             .search_nodes("test", None, None, None)
             .await
             .unwrap();
@@ -413,6 +442,7 @@ pub mod tests {
             .create();
 
         let nodes = dracoon
+            .nodes
             .search_nodes("test", Some(123), None, None)
             .await
             .unwrap();
@@ -447,6 +477,7 @@ pub mod tests {
         let params = ListAllParams::builder().with_limit(100).build();
 
         let nodes = dracoon
+            .nodes
             .search_nodes("test", None, None, Some(params))
             .await
             .unwrap();
@@ -478,6 +509,7 @@ pub mod tests {
         let params = ListAllParams::builder().with_offset(500).build();
 
         let nodes = dracoon
+            .nodes
             .search_nodes("test", None, None, Some(params))
             .await
             .unwrap();
@@ -514,6 +546,7 @@ pub mod tests {
             .build();
 
         let nodes = dracoon
+            .nodes
             .search_nodes("test", None, None, Some(params))
             .await
             .unwrap();
@@ -550,6 +583,7 @@ pub mod tests {
             .build();
 
         let nodes = dracoon
+            .nodes
             .search_nodes("test", None, None, Some(params))
             .await
             .unwrap();
@@ -582,6 +616,7 @@ pub mod tests {
             .create();
 
         let nodes = dracoon
+            .nodes
             .search_nodes("test", None, Some(-1), None)
             .await
             .unwrap();

--- a/src/tests/provisioning.rs
+++ b/src/tests/provisioning.rs
@@ -80,7 +80,7 @@ mod tests {
             .with_body(customers_res)
             .create();
 
-        let customers = dracoon.get_customers(None).await.unwrap();
+        let customers = dracoon.provisioning.get_customers(None).await.unwrap();
         assert_eq!(customers.range.total, 1);
         assert_eq!(customers.range.offset, 0);
         assert_eq!(customers.range.limit, 0);
@@ -106,7 +106,11 @@ mod tests {
 
         let params = ListAllParams::builder().with_limit(100).build();
 
-        let customers = dracoon.get_customers(Some(params)).await.unwrap();
+        let customers = dracoon
+            .provisioning
+            .get_customers(Some(params))
+            .await
+            .unwrap();
         assert_eq!(customers.range.total, 1);
         assert_eq!(customers.range.offset, 0);
         assert_eq!(customers.range.limit, 0);
@@ -132,7 +136,11 @@ mod tests {
 
         let params = ListAllParams::builder().with_offset(500).build();
 
-        let customers = dracoon.get_customers(Some(params)).await.unwrap();
+        let customers = dracoon
+            .provisioning
+            .get_customers(Some(params))
+            .await
+            .unwrap();
         assert_eq!(customers.range.total, 1);
         assert_eq!(customers.range.offset, 0);
         assert_eq!(customers.range.limit, 0);
@@ -161,7 +169,11 @@ mod tests {
         // TODO: add filter query
         let params = ListAllParams::builder().build();
 
-        let customers = dracoon.get_customers(Some(params)).await.unwrap();
+        let customers = dracoon
+            .provisioning
+            .get_customers(Some(params))
+            .await
+            .unwrap();
         assert_eq!(customers.range.total, 1);
         assert_eq!(customers.range.offset, 0);
         assert_eq!(customers.range.limit, 0);
@@ -188,7 +200,7 @@ mod tests {
             .create();
 
         // TODO: add sort query
-        let customers = dracoon.get_customers(None).await.unwrap();
+        let customers = dracoon.provisioning.get_customers(None).await.unwrap();
         assert_eq!(customers.range.total, 1);
         assert_eq!(customers.range.offset, 0);
         assert_eq!(customers.range.limit, 0);
@@ -219,7 +231,11 @@ mod tests {
             .with_company_name("test")
             .build();
 
-        let customer = dracoon.create_customer(customer).await.unwrap();
+        let customer = dracoon
+            .provisioning
+            .create_customer(customer)
+            .await
+            .unwrap();
 
         assert_eq!(customer.id, 1);
         assert_eq!(customer.company_name, "string");
@@ -274,7 +290,7 @@ mod tests {
             .with_body(res)
             .create();
 
-        let customer = dracoon.get_customer(1, None).await.unwrap();
+        let customer = dracoon.provisioning.get_customer(1, None).await.unwrap();
 
         assert_customer(&customer).await;
 
@@ -296,7 +312,11 @@ mod tests {
             .with_body(res)
             .create();
 
-        let customer = dracoon.get_customer(1, Some(true)).await.unwrap();
+        let customer = dracoon
+            .provisioning
+            .get_customer(1, Some(true))
+            .await
+            .unwrap();
 
         assert_customer(&customer).await;
 
@@ -319,7 +339,11 @@ mod tests {
             .with_quota_max(1000000000)
             .build();
 
-        let customer = dracoon.update_customer(1, customer).await.unwrap();
+        let customer = dracoon
+            .provisioning
+            .update_customer(1, customer)
+            .await
+            .unwrap();
 
         assert_eq!(customer.id, 1);
         assert_eq!(customer.company_name, "string");
@@ -343,7 +367,7 @@ mod tests {
             .with_status(204)
             .create();
 
-        let res = dracoon.delete_customer(1).await;
+        let res = dracoon.provisioning.delete_customer(1).await;
         assert!(res.is_ok());
     }
 
@@ -359,7 +383,11 @@ mod tests {
             .with_body(res)
             .create();
 
-        let users = dracoon.get_customer_users(1, None).await.unwrap();
+        let users = dracoon
+            .provisioning
+            .get_customer_users(1, None)
+            .await
+            .unwrap();
 
         assert_eq!(users.items.len(), 1);
 
@@ -385,7 +413,11 @@ mod tests {
 
         let params = ListAllParams::builder().with_limit(100).build();
 
-        let users = dracoon.get_customer_users(1, Some(params)).await.unwrap();
+        let users = dracoon
+            .provisioning
+            .get_customer_users(1, Some(params))
+            .await
+            .unwrap();
 
         assert_eq!(users.items.len(), 1);
 
@@ -408,7 +440,11 @@ mod tests {
 
         let params = ListAllParams::builder().with_offset(500).build();
 
-        let users = dracoon.get_customer_users(1, Some(params)).await.unwrap();
+        let users = dracoon
+            .provisioning
+            .get_customer_users(1, Some(params))
+            .await
+            .unwrap();
 
         assert_eq!(users.items.len(), 1);
 

--- a/src/tests/rooms.rs
+++ b/src/tests/rooms.rs
@@ -105,7 +105,7 @@ mod tests {
 
         let room_req = CreateRoomRequest::builder("test").build();
 
-        let room = client.create_room(room_req).await.unwrap();
+        let room = client.nodes.create_room(room_req).await.unwrap();
 
         assert_node(&room);
     }
@@ -125,7 +125,7 @@ mod tests {
 
         let update = UpdateRoomRequest::builder().with_quota(1234567890).build();
 
-        let room = client.update_room(123, update).await.unwrap();
+        let room = client.nodes.update_room(123, update).await.unwrap();
 
         assert_node(&room);
     }
@@ -148,7 +148,7 @@ mod tests {
             .with_admin_ids(vec![1])
             .build();
 
-        let room = client.config_room(123, config).await.unwrap();
+        let room = client.nodes.config_room(123, config).await.unwrap();
 
         assert_node(&room);
     }
@@ -166,7 +166,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let room_policies = client.get_room_policies(123).await.unwrap();
+        let room_policies = client.nodes.get_room_policies(123).await.unwrap();
 
         assert_eq!(room_policies.default_expiration_period, 0);
         assert!(!room_policies.is_virus_protection_enabled);
@@ -187,7 +187,7 @@ mod tests {
             .with_virus_protection_enabled(true)
             .build();
 
-        let result = client.update_room_policies(123, room_policies).await;
+        let result = client.nodes.update_room_policies(123, room_policies).await;
 
         assert!(result.is_ok());
     }
@@ -209,7 +209,7 @@ mod tests {
             .with_use_data_space_rescue_key(true)
             .build();
 
-        let room = client.encrypt_room(123, room_enc).await.unwrap();
+        let room = client.nodes.encrypt_room(123, room_enc).await.unwrap();
 
         assert_node(&room);
     }
@@ -232,7 +232,7 @@ mod tests {
             .unwrap()
             .build();
 
-        let room = client.encrypt_room(123, room_enc).await.unwrap();
+        let room = client.nodes.encrypt_room(123, room_enc).await.unwrap();
 
         assert_node(&room);
     }
@@ -250,7 +250,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let room_users = client.get_room_users(123, None).await.unwrap();
+        let room_users = client.nodes.get_room_users(123, None).await.unwrap();
 
         assert_eq!(room_users.range.total, 1);
         assert_eq!(room_users.items.len(), 1);
@@ -277,7 +277,11 @@ mod tests {
 
         let params = ListAllParams::builder().with_limit(100).build();
 
-        let room_users = client.get_room_users(123, Some(params)).await.unwrap();
+        let room_users = client
+            .nodes
+            .get_room_users(123, Some(params))
+            .await
+            .unwrap();
 
         assert_eq!(room_users.range.total, 1);
         assert_eq!(room_users.items.len(), 1);
@@ -304,7 +308,11 @@ mod tests {
 
         let params = ListAllParams::builder().with_offset(500).build();
 
-        let room_users = client.get_room_users(123, Some(params)).await.unwrap();
+        let room_users = client
+            .nodes
+            .get_room_users(123, Some(params))
+            .await
+            .unwrap();
 
         assert_eq!(room_users.range.total, 1);
         assert_eq!(room_users.items.len(), 1);
@@ -331,6 +339,7 @@ mod tests {
         )];
 
         client
+            .nodes
             .update_room_users(123, user_updates.into())
             .await
             .unwrap();
@@ -350,6 +359,7 @@ mod tests {
         let user_ids = vec![1, 2, 3];
 
         client
+            .nodes
             .delete_room_users(123, user_ids.into())
             .await
             .unwrap();
@@ -370,7 +380,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let room_groups = client.get_room_groups(123, None).await.unwrap();
+        let room_groups = client.nodes.get_room_groups(123, None).await.unwrap();
 
         room_groups_mock.assert();
 
@@ -396,7 +406,11 @@ mod tests {
 
         let params = ListAllParams::builder().with_limit(100).build();
 
-        let room_groups = client.get_room_groups(123, Some(params)).await.unwrap();
+        let room_groups = client
+            .nodes
+            .get_room_groups(123, Some(params))
+            .await
+            .unwrap();
 
         room_groups_mock.assert();
 
@@ -422,7 +436,11 @@ mod tests {
 
         let params = ListAllParams::builder().with_offset(500).build();
 
-        let room_groups = client.get_room_groups(123, Some(params)).await.unwrap();
+        let room_groups = client
+            .nodes
+            .get_room_groups(123, Some(params))
+            .await
+            .unwrap();
 
         assert_eq!(room_groups.range.total, 1);
         assert_eq!(room_groups.items.len(), 1);
@@ -450,6 +468,7 @@ mod tests {
         )];
 
         client
+            .nodes
             .update_room_groups(123, group_updates.into())
             .await
             .unwrap();
@@ -469,6 +488,7 @@ mod tests {
         let group_ids = vec![1, 2, 3];
 
         client
+            .nodes
             .delete_room_groups(123, group_ids.into())
             .await
             .unwrap();

--- a/src/tests/shares.rs
+++ b/src/tests/shares.rs
@@ -123,7 +123,11 @@ mod download_share_tests {
 
         let params = ListAllParams::builder().with_limit(100).build();
 
-        let shares = client.shares.get_download_shares(Some(params)).await.unwrap();
+        let shares = client
+            .shares
+            .get_download_shares(Some(params))
+            .await
+            .unwrap();
 
         shares_mock.assert();
 
@@ -150,7 +154,11 @@ mod download_share_tests {
 
         let params = ListAllParams::builder().with_offset(500).build();
 
-        let shares = client.shares.get_download_shares(Some(params)).await.unwrap();
+        let shares = client
+            .shares
+            .get_download_shares(Some(params))
+            .await
+            .unwrap();
 
         shares_mock.assert();
 
@@ -182,7 +190,11 @@ mod download_share_tests {
             .with_filter(DownloadSharesFilter::name_contains("test"))
             .build();
 
-        let shares = client.shares.get_download_shares(Some(params)).await.unwrap();
+        let shares = client
+            .shares
+            .get_download_shares(Some(params))
+            .await
+            .unwrap();
 
         shares_mock.assert();
 
@@ -211,7 +223,11 @@ mod download_share_tests {
             .with_sort(DownloadSharesSortBy::Name(SortOrder::Asc))
             .build();
 
-        let shares = client.shares.get_download_shares(Some(params)).await.unwrap();
+        let shares = client
+            .shares
+            .get_download_shares(Some(params))
+            .await
+            .unwrap();
 
         shares_mock.assert();
 
@@ -328,7 +344,11 @@ mod download_share_tests {
             .with_max_downloads(2)
             .build();
 
-        let share = client.shares.update_download_share(123, update).await.unwrap();
+        let share = client
+            .shares
+            .update_download_share(123, update)
+            .await
+            .unwrap();
 
         share_mock.assert();
 
@@ -722,7 +742,11 @@ mod upload_share_tests {
             .with_notes("test")
             .build();
 
-        let share = client.shares.update_upload_share(123, update).await.unwrap();
+        let share = client
+            .shares
+            .update_upload_share(123, update)
+            .await
+            .unwrap();
 
         share_mock.assert();
 

--- a/src/tests/shares.rs
+++ b/src/tests/shares.rs
@@ -96,7 +96,7 @@ mod download_share_tests {
             .with_body(shares_res)
             .create();
 
-        let shares = client.get_download_shares(None).await.unwrap();
+        let shares = client.shares.get_download_shares(None).await.unwrap();
 
         shares_mock.assert();
 
@@ -123,7 +123,7 @@ mod download_share_tests {
 
         let params = ListAllParams::builder().with_limit(100).build();
 
-        let shares = client.get_download_shares(Some(params)).await.unwrap();
+        let shares = client.shares.get_download_shares(Some(params)).await.unwrap();
 
         shares_mock.assert();
 
@@ -150,7 +150,7 @@ mod download_share_tests {
 
         let params = ListAllParams::builder().with_offset(500).build();
 
-        let shares = client.get_download_shares(Some(params)).await.unwrap();
+        let shares = client.shares.get_download_shares(Some(params)).await.unwrap();
 
         shares_mock.assert();
 
@@ -182,7 +182,7 @@ mod download_share_tests {
             .with_filter(DownloadSharesFilter::name_contains("test"))
             .build();
 
-        let shares = client.get_download_shares(Some(params)).await.unwrap();
+        let shares = client.shares.get_download_shares(Some(params)).await.unwrap();
 
         shares_mock.assert();
 
@@ -211,7 +211,7 @@ mod download_share_tests {
             .with_sort(DownloadSharesSortBy::Name(SortOrder::Asc))
             .build();
 
-        let shares = client.get_download_shares(Some(params)).await.unwrap();
+        let shares = client.shares.get_download_shares(Some(params)).await.unwrap();
 
         shares_mock.assert();
 
@@ -240,7 +240,7 @@ mod download_share_tests {
             .with_max_downloads(2)
             .build();
 
-        let res = client.update_download_shares(update).await;
+        let res = client.shares.update_download_shares(update).await;
 
         shares_mock.assert();
         assert!(res.is_ok());
@@ -259,7 +259,7 @@ mod download_share_tests {
 
         let update = DeleteDownloadSharesRequest::new(share_ids);
 
-        let res = client.delete_download_shares(update).await;
+        let res = client.shares.delete_download_shares(update).await;
 
         shares_mock.assert();
         assert!(res.is_ok());
@@ -283,7 +283,7 @@ mod download_share_tests {
             .with_max_downloads(2)
             .build();
 
-        let share = client.create_download_share(share).await.unwrap();
+        let share = client.shares.create_download_share(share).await.unwrap();
 
         share_mock.assert();
 
@@ -303,7 +303,7 @@ mod download_share_tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let share = client.get_download_share(123).await.unwrap();
+        let share = client.shares.get_download_share(123).await.unwrap();
 
         share_mock.assert();
 
@@ -328,7 +328,7 @@ mod download_share_tests {
             .with_max_downloads(2)
             .build();
 
-        let share = client.update_download_share(123, update).await.unwrap();
+        let share = client.shares.update_download_share(123, update).await.unwrap();
 
         share_mock.assert();
 
@@ -346,7 +346,7 @@ mod download_share_tests {
             .with_status(204)
             .create();
 
-        let res = client.delete_download_share(123).await;
+        let res = client.shares.delete_download_share(123).await;
 
         share_mock.assert();
 
@@ -366,7 +366,7 @@ mod download_share_tests {
 
         let email = DownloadShareLinkEmail::new("test", vec!["foo@localhost".into()], None);
 
-        let res = client.send_download_share_email(123, email).await;
+        let res = client.shares.send_download_share_email(123, email).await;
 
         share_mock.assert();
 
@@ -472,7 +472,7 @@ mod upload_share_tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let shares = client.get_upload_shares(None).await.unwrap();
+        let shares = client.shares.get_upload_shares(None).await.unwrap();
 
         share_mock.assert();
 
@@ -502,7 +502,7 @@ mod upload_share_tests {
 
         let params = ListAllParams::builder().with_limit(100).build();
 
-        let shares = client.get_upload_shares(Some(params)).await.unwrap();
+        let shares = client.shares.get_upload_shares(Some(params)).await.unwrap();
 
         share_mock.assert();
 
@@ -532,7 +532,7 @@ mod upload_share_tests {
 
         let params = ListAllParams::builder().with_offset(500).build();
 
-        let shares = client.get_upload_shares(Some(params)).await.unwrap();
+        let shares = client.shares.get_upload_shares(Some(params)).await.unwrap();
 
         share_mock.assert();
 
@@ -567,7 +567,7 @@ mod upload_share_tests {
             .with_filter(UploadSharesFilter::user_id_equals(2))
             .build();
 
-        let shares = client.get_upload_shares(Some(params)).await.unwrap();
+        let shares = client.shares.get_upload_shares(Some(params)).await.unwrap();
 
         share_mock.assert();
 
@@ -599,7 +599,7 @@ mod upload_share_tests {
             .with_sort(UploadSharesSortBy::Name(SortOrder::Asc))
             .build();
 
-        let shares = client.get_upload_shares(Some(params)).await.unwrap();
+        let shares = client.shares.get_upload_shares(Some(params)).await.unwrap();
 
         share_mock.assert();
 
@@ -631,7 +631,7 @@ mod upload_share_tests {
             .with_show_uploaded_files(true)
             .build();
 
-        let res = client.update_upload_shares(update).await;
+        let res = client.shares.update_upload_shares(update).await;
 
         shares_mock.assert();
 
@@ -649,7 +649,7 @@ mod upload_share_tests {
 
         let share_ids = vec![1, 2, 3];
 
-        let res = client.delete_upload_shares(share_ids.into()).await;
+        let res = client.shares.delete_upload_shares(share_ids.into()).await;
 
         shares_mock.assert();
 
@@ -677,7 +677,7 @@ mod upload_share_tests {
             .with_show_creator_username(true)
             .build();
 
-        let share = client.create_upload_share(share).await.unwrap();
+        let share = client.shares.create_upload_share(share).await.unwrap();
 
         share_mock.assert();
 
@@ -697,7 +697,7 @@ mod upload_share_tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let share = client.get_upload_share(123).await.unwrap();
+        let share = client.shares.get_upload_share(123).await.unwrap();
 
         share_mock.assert();
 
@@ -722,7 +722,7 @@ mod upload_share_tests {
             .with_notes("test")
             .build();
 
-        let share = client.update_upload_share(123, update).await.unwrap();
+        let share = client.shares.update_upload_share(123, update).await.unwrap();
 
         share_mock.assert();
 
@@ -738,7 +738,7 @@ mod upload_share_tests {
             .with_status(204)
             .create();
 
-        let res = client.delete_upload_share(123).await;
+        let res = client.shares.delete_upload_share(123).await;
 
         shares_mock.assert();
 
@@ -756,7 +756,7 @@ mod upload_share_tests {
 
         let email = UploadShareLinkEmail::new("test", vec!["foo@localhost".into()], None);
 
-        let res = client.send_upload_share_email(123, email).await;
+        let res = client.shares.send_upload_share_email(123, email).await;
 
         shares_mock.assert();
 

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -26,7 +26,7 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let keypair = client.get_user_keypair("TopSecret1234!").await.unwrap();
+        let keypair = client.user.get_user_keypair("TopSecret1234!").await.unwrap();
 
         keypair_mock.assert();
 
@@ -58,7 +58,7 @@ mod tests {
             .with_status(204)
             .create();
 
-        let res = client.set_user_keypair("TopSecret1234!").await;
+        let res = client.user.set_user_keypair("TopSecret1234!").await;
 
         keypair_mock.assert();
 
@@ -75,7 +75,7 @@ mod tests {
             .with_status(204)
             .create();
 
-        let res = client.delete_user_keypair().await;
+        let res = client.user.delete_user_keypair().await;
 
         keypair_mock.assert();
 
@@ -94,7 +94,7 @@ mod tests {
             .with_body(account_res)
             .create();
 
-        let user_account = client.get_user_account().await.unwrap();
+        let user_account = client.user.get_user_account().await.unwrap();
 
         user_account_mock.assert();
 
@@ -121,7 +121,7 @@ mod tests {
             .with_email("test@localhost")
             .build();
 
-        let user_account = client.update_user_account(update).await.unwrap();
+        let user_account = client.user.update_user_account(update).await.unwrap();
 
         user_account_mock.assert();
 

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -26,7 +26,11 @@ mod tests {
             .with_header("content-type", "application/json")
             .create();
 
-        let keypair = client.user.get_user_keypair("TopSecret1234!").await.unwrap();
+        let keypair = client
+            .user
+            .get_user_keypair("TopSecret1234!")
+            .await
+            .unwrap();
 
         keypair_mock.assert();
 

--- a/src/tests/users.rs
+++ b/src/tests/users.rs
@@ -237,7 +237,7 @@ pub mod tests {
             .with_body(user_res)
             .create();
 
-        let auth = UserAuthData::new_basic(None);
+        let auth = UserAuthData::new_basic(None, None);
         let user_req = CreateUserRequest::builder("test", "test")
             .with_email("test@localhost")
             .with_auth_data(auth)

--- a/src/tests/users.rs
+++ b/src/tests/users.rs
@@ -47,7 +47,7 @@ pub mod tests {
             .with_body(users_res)
             .create();
 
-        let users = client.get_users(None, None, None).await.unwrap();
+        let users = client.users.get_users(None, None, None).await.unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -71,7 +71,7 @@ pub mod tests {
 
         let params = ListAllParams::builder().with_limit(100).build();
 
-        let users = client.get_users(Some(params), None, None).await.unwrap();
+        let users = client.users.get_users(Some(params), None, None).await.unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -95,7 +95,7 @@ pub mod tests {
 
         let params = ListAllParams::builder().with_offset(500).build();
 
-        let users = client.get_users(Some(params), None, None).await.unwrap();
+        let users = client.users.get_users(Some(params), None, None).await.unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -121,7 +121,7 @@ pub mod tests {
             .with_sort(UsersSortBy::CreatedAt(SortOrder::Asc))
             .build();
 
-        let users = client.get_users(Some(params), None, None).await.unwrap();
+        let users = client.users.get_users(Some(params), None, None).await.unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -147,7 +147,7 @@ pub mod tests {
             .with_filter(UsersFilter::email_contains("test"))
             .build();
 
-        let users = client.get_users(Some(params), None, None).await.unwrap();
+        let users = client.users.get_users(Some(params), None, None).await.unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -169,7 +169,7 @@ pub mod tests {
             .with_body(users_res)
             .create();
 
-        let users = client.get_users(None, Some(true), None).await.unwrap();
+        let users = client.users.get_users(None, Some(true), None).await.unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -191,7 +191,7 @@ pub mod tests {
             .with_body(users_res)
             .create();
 
-        let users = client.get_users(None, None, Some(true)).await.unwrap();
+        let users = client.users.get_users(None, None, Some(true)).await.unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -219,7 +219,7 @@ pub mod tests {
             .with_auth_data(auth)
             .build();
 
-        let user = client.create_user(user_req).await.unwrap();
+        let user = client.users.create_user(user_req).await.unwrap();
 
         user_mock.assert();
 
@@ -238,7 +238,7 @@ pub mod tests {
             .with_body(user_res)
             .create();
 
-        let user = client.get_user(123, None).await.unwrap();
+        let user = client.users.get_user(123, None).await.unwrap();
 
         user_mock.assert();
 
@@ -260,7 +260,7 @@ pub mod tests {
             .with_email("foo@localhost")
             .build();
 
-        let user = client.update_user(123, user_req).await.unwrap();
+        let user = client.users.update_user(123, user_req).await.unwrap();
 
         user_mock.assert();
 
@@ -278,7 +278,7 @@ pub mod tests {
             .with_body(user_res)
             .create();
 
-        let res = client.delete_user(123).await;
+        let res = client.users.delete_user(123).await;
 
         assert!(res.is_ok());
 

--- a/src/tests/users.rs
+++ b/src/tests/users.rs
@@ -71,7 +71,11 @@ pub mod tests {
 
         let params = ListAllParams::builder().with_limit(100).build();
 
-        let users = client.users.get_users(Some(params), None, None).await.unwrap();
+        let users = client
+            .users
+            .get_users(Some(params), None, None)
+            .await
+            .unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -95,7 +99,11 @@ pub mod tests {
 
         let params = ListAllParams::builder().with_offset(500).build();
 
-        let users = client.users.get_users(Some(params), None, None).await.unwrap();
+        let users = client
+            .users
+            .get_users(Some(params), None, None)
+            .await
+            .unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -121,7 +129,11 @@ pub mod tests {
             .with_sort(UsersSortBy::CreatedAt(SortOrder::Asc))
             .build();
 
-        let users = client.users.get_users(Some(params), None, None).await.unwrap();
+        let users = client
+            .users
+            .get_users(Some(params), None, None)
+            .await
+            .unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -147,7 +159,11 @@ pub mod tests {
             .with_filter(UsersFilter::email_contains("test"))
             .build();
 
-        let users = client.users.get_users(Some(params), None, None).await.unwrap();
+        let users = client
+            .users
+            .get_users(Some(params), None, None)
+            .await
+            .unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -169,7 +185,11 @@ pub mod tests {
             .with_body(users_res)
             .create();
 
-        let users = client.users.get_users(None, Some(true), None).await.unwrap();
+        let users = client
+            .users
+            .get_users(None, Some(true), None)
+            .await
+            .unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);
@@ -191,7 +211,11 @@ pub mod tests {
             .with_body(users_res)
             .create();
 
-        let users = client.users.get_users(None, None, Some(true)).await.unwrap();
+        let users = client
+            .users
+            .get_users(None, None, Some(true))
+            .await
+            .unwrap();
 
         users_mock.assert();
         assert_eq!(users.range.offset, 0);

--- a/src/user/account.rs
+++ b/src/user/account.rs
@@ -5,26 +5,28 @@ use crate::{
     auth::{errors::DracoonClientError, Connected},
     constants::{DRACOON_API_PREFIX, USER_ACCOUNT, USER_BASE},
     utils::FromResponse,
-    Dracoon,
 };
 
 use super::{
     models::{UpdateUserAccountRequest, UserAccount},
-    User,
+    User, UserEndpoint,
 };
 
 #[async_trait]
-impl User for Dracoon<Connected> {
+impl User for UserEndpoint<Connected> {
     async fn get_user_account(&self) -> Result<UserAccount, DracoonClientError> {
         let url_part = format!("{DRACOON_API_PREFIX}/{USER_BASE}/{USER_ACCOUNT}");
 
-        let url = self.build_api_url(&url_part);
+        let url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -37,13 +39,16 @@ impl User for Dracoon<Connected> {
     ) -> Result<UserAccount, DracoonClientError> {
         let url_part = format!("{DRACOON_API_PREFIX}/{USER_BASE}/{USER_ACCOUNT}");
 
-        let url = self.build_api_url(&url_part);
+        let url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&update)
             .send()

--- a/src/user/keypairs.rs
+++ b/src/user/keypairs.rs
@@ -1,9 +1,8 @@
-use super::UserAccountKeyPairs;
+use super::{UserAccountKeyPairs, UserEndpoint};
 use crate::{
     auth::{errors::DracoonClientError, Connected},
     constants::{DRACOON_API_PREFIX, USER_ACCOUNT, USER_ACCOUNT_KEYPAIR, USER_BASE},
     utils::FromResponse,
-    Dracoon,
 };
 use async_trait::async_trait;
 use dco3_crypto::{
@@ -12,7 +11,7 @@ use dco3_crypto::{
 use reqwest::header;
 
 #[async_trait]
-impl UserAccountKeyPairs for Dracoon<Connected> {
+impl UserAccountKeyPairs for UserEndpoint<Connected>  {
     async fn get_user_keypair(
         &self,
         secret: &str,
@@ -20,13 +19,13 @@ impl UserAccountKeyPairs for Dracoon<Connected> {
         let url_part =
             format!("{DRACOON_API_PREFIX}/{USER_BASE}/{USER_ACCOUNT}/{USER_ACCOUNT_KEYPAIR}");
 
-        let url = self.build_api_url(&url_part);
+        let url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -41,17 +40,17 @@ impl UserAccountKeyPairs for Dracoon<Connected> {
         let url_part =
             format!("{DRACOON_API_PREFIX}/{USER_BASE}/{USER_ACCOUNT}/{USER_ACCOUNT_KEYPAIR}");
 
-        let url = self.build_api_url(&url_part);
+        let url = self.client().build_api_url(&url_part);
 
         let version = dco3_crypto::UserKeyPairVersion::RSA4096;
         let keypair = DracoonCrypto::create_plain_user_keypair(version)?;
         let enc_keypair = DracoonCrypto::encrypt_private_key(secret, keypair)?;
 
         let response = self
-            .client
+            .client()
             .http
             .post(url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .header(header::CONTENT_TYPE, "application/json")
             .json(&enc_keypair)
             .send()
@@ -64,13 +63,13 @@ impl UserAccountKeyPairs for Dracoon<Connected> {
         let url_part =
             format!("{DRACOON_API_PREFIX}/{USER_BASE}/{USER_ACCOUNT}/{USER_ACCOUNT_KEYPAIR}");
 
-        let url = self.build_api_url(&url_part);
+        let url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;

--- a/src/user/keypairs.rs
+++ b/src/user/keypairs.rs
@@ -11,7 +11,7 @@ use dco3_crypto::{
 use reqwest::header;
 
 #[async_trait]
-impl UserAccountKeyPairs for UserEndpoint<Connected>  {
+impl UserAccountKeyPairs for UserEndpoint<Connected> {
     async fn get_user_keypair(
         &self,
         secret: &str,
@@ -25,7 +25,10 @@ impl UserAccountKeyPairs for UserEndpoint<Connected>  {
             .client()
             .http
             .get(url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
@@ -50,7 +53,10 @@ impl UserAccountKeyPairs for UserEndpoint<Connected>  {
             .client()
             .http
             .post(url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&enc_keypair)
             .send()
@@ -69,7 +75,10 @@ impl UserAccountKeyPairs for UserEndpoint<Connected>  {
             .client()
             .http
             .delete(url)
-            .header(header::AUTHORIZATION, self.client().get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .send()
             .await?;

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -27,7 +27,7 @@ pub trait User {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let account = dracoon.get_user_account().await.unwrap();
+    /// let account = dracoon.user.get_user_account().await.unwrap();
     /// # }
     /// ```
     async fn get_user_account(&self) -> Result<UserAccount, DracoonClientError>;
@@ -52,7 +52,7 @@ pub trait User {
     ///                      .with_email("jane.doe@localhost")
     ///                      .build();
     ///
-    /// let account = dracoon.update_user_account(update).await.unwrap();
+    /// let account = dracoon.user.update_user_account(update).await.unwrap();
     /// # }
     /// ```  
     async fn update_user_account(
@@ -78,7 +78,7 @@ pub trait UserAccountKeyPairs {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let keypair = dracoon.get_user_keypair("secret123").await.unwrap();
+    /// let keypair = dracoon.user.get_user_keypair("secret123").await.unwrap();
     /// // note: you will usually not need the plain keypair since encryption / decryption
     /// // is handled by the dracoon client for up- and downloads.
     /// # }
@@ -101,7 +101,7 @@ pub trait UserAccountKeyPairs {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// dracoon.set_user_keypair("Secret123!").await.unwrap();
+    /// dracoon.user.set_user_keypair("Secret123!").await.unwrap();
     /// // note: you need to delete the existing keypair before setting a new one.
     /// # }
     /// ```
@@ -120,7 +120,7 @@ pub trait UserAccountKeyPairs {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// dracoon.delete_user_keypair().await.unwrap();
+    /// dracoon.user.delete_user_keypair().await.unwrap();
     /// // note: you need to delete the existing keypair before setting a new one.
     /// # }
     /// ```

--- a/src/user/models.rs
+++ b/src/user/models.rs
@@ -16,7 +16,6 @@ use crate::{
 pub struct UserEndpoint<S> {
     client: Arc<DracoonClient<S>>,
     state: std::marker::PhantomData<S>,
-
 }
 
 impl <S> UserEndpoint<S> {

--- a/src/user/models.rs
+++ b/src/user/models.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dco3_crypto::UserKeyPairContainer;
@@ -6,9 +8,29 @@ use reqwest::Response;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    auth::{errors::DracoonClientError, models::DracoonErrorResponse},
+    auth::{errors::DracoonClientError, models::DracoonErrorResponse, DracoonClient},
     utils::{parse_body, FromResponse},
 };
+
+#[derive(Clone)]
+pub struct UserEndpoint<S> {
+    client: Arc<DracoonClient<S>>,
+    state: std::marker::PhantomData<S>,
+
+}
+
+impl <S> UserEndpoint<S> {
+    pub fn new(client: Arc<DracoonClient<S>>) -> Self {
+        Self {
+            client,
+            state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn client(&self) -> &Arc<DracoonClient<S>> {
+        &self.client
+    }
+}
 
 #[derive(Debug, Deserialize, Clone, FromResponse)]
 #[serde(rename_all = "camelCase")]

--- a/src/user/models.rs
+++ b/src/user/models.rs
@@ -18,7 +18,7 @@ pub struct UserEndpoint<S> {
     state: std::marker::PhantomData<S>,
 }
 
-impl <S> UserEndpoint<S> {
+impl<S> UserEndpoint<S> {
     pub fn new(client: Arc<DracoonClient<S>>) -> Self {
         Self {
             client,

--- a/src/users/mod.rs
+++ b/src/users/mod.rs
@@ -55,7 +55,7 @@ pub trait Users {
     /// #  .await
     /// #  .unwrap();
     /// // optionally a password can be set for local users
-    /// let auth = UserAuthData::new_basic(None);
+    /// let auth = UserAuthData::new_basic(None, None);
     /// let user = CreateUserRequest::builder("Jane", "Doe")
     ///    .with_user_name("jane.doe")
     ///    .with_email("jane.doe@localhost")

--- a/src/users/mod.rs
+++ b/src/users/mod.rs
@@ -30,7 +30,7 @@ pub trait Users {
     ///     .with_sort(UsersSortBy::user_name(SortOrder::Desc))
     ///     .build();
     /// // optionally include roles and attributes
-    /// let users = dracoon.get_users(Some(params), None, None).await.unwrap();
+    /// let users = dracoon.users.get_users(Some(params), None, None).await.unwrap();
     ///
     /// # }
     /// ```
@@ -61,7 +61,7 @@ pub trait Users {
     ///    .with_email("jane.doe@localhost")
     ///    .with_auth_data(auth)
     ///    .build();
-    /// let user = dracoon.create_user(user).await.unwrap();
+    /// let user = dracoon.users.create_user(user).await.unwrap();
     ///
     /// // creating an OIDC user
     /// let auth = UserAuthData::new_oidc("jane.doe", 4);
@@ -69,7 +69,7 @@ pub trait Users {
     ///    .with_email("jane.doe@localhost")
     ///    .with_auth_data(auth)
     ///    .build();
-    /// let user = dracoon.create_user(user).await.unwrap();
+    /// let user = dracoon.users.create_user(user).await.unwrap();
     /// # }
     /// ```
     async fn create_user(&self, req: CreateUserRequest) -> Result<UserData, DracoonClientError>;
@@ -88,7 +88,7 @@ pub trait Users {
     /// #  .await
     /// #  .unwrap();
     /// // optionally you can include effective roles
-    /// let user = dracoon.get_user(123, None).await.unwrap();
+    /// let user = dracoon.users.get_user(123, None).await.unwrap();
     /// # }
     /// ```
     async fn get_user(
@@ -114,7 +114,7 @@ pub trait Users {
     ///    .with_first_name("Jane")
     ///    .with_last_name("Doe")
     ///    .build();
-    /// let user = dracoon.update_user(123, update).await.unwrap();
+    /// let user = dracoon.users.update_user(123, update).await.unwrap();
     /// # }
     /// ```
     async fn update_user(
@@ -136,7 +136,7 @@ pub trait Users {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// dracoon.delete_user(123).await.unwrap();
+    /// dracoon.users.delete_user(123).await.unwrap();
     ///
     /// # }
     /// ```
@@ -155,7 +155,7 @@ pub trait Users {
     /// #  .connect(OAuth2Flow::PasswordFlow("username".into(), "password".into()))
     /// #  .await
     /// #  .unwrap();
-    /// let rooms = dracoon.get_user_last_admin_rooms(123).await.unwrap();
+    /// let rooms = dracoon.users.get_user_last_admin_rooms(123).await.unwrap();
     /// # }
     /// ```
     async fn get_user_last_admin_rooms(

--- a/src/users/models.rs
+++ b/src/users/models.rs
@@ -23,7 +23,7 @@ pub struct UsersEndpoint<S> {
     state: std::marker::PhantomData<S>,
 }
 
-impl <S> UsersEndpoint<S> {
+impl<S> UsersEndpoint<S> {
     pub fn new(client: Arc<DracoonClient<S>>) -> Self {
         Self {
             client,

--- a/src/users/models.rs
+++ b/src/users/models.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dco3_crypto::PublicKeyContainer;
@@ -6,7 +8,7 @@ use reqwest::Response;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    auth::DracoonErrorResponse,
+    auth::{DracoonClient, DracoonErrorResponse},
     models::{ObjectExpiration, RangedItems},
     user::RoleList,
     utils::{parse_body, FromResponse},
@@ -14,6 +16,25 @@ use crate::{
 };
 
 pub use crate::user::UserAuthData;
+
+#[derive(Clone)]
+pub struct UsersEndpoint<S> {
+    client: Arc<DracoonClient<S>>,
+    state: std::marker::PhantomData<S>,
+}
+
+impl <S> UsersEndpoint<S> {
+    pub fn new(client: Arc<DracoonClient<S>>) -> Self {
+        Self {
+            client,
+            state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn client(&self) -> &Arc<DracoonClient<S>> {
+        &self.client
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, FromResponse)]
 #[serde(rename_all = "camelCase")]

--- a/src/users/models.rs
+++ b/src/users/models.rs
@@ -427,8 +427,14 @@ impl UserAuthData {
         UserAuthDataBuilder::new(auth_method)
     }
 
-    pub fn new_basic(password: Option<String>) -> Self {
-        let must_change_password = password.is_some();
+    pub fn new_basic(password: Option<String>, must_change_password: Option<bool>) -> Self {
+        // password change is default (notify user is also default)
+        let mut must_change_password = must_change_password.unwrap_or(true);
+
+        // password must be changed if set on creation
+        if password.is_some() && !must_change_password {
+            must_change_password = true;
+        }
 
         Self {
             method: AuthMethod::Basic.into(),

--- a/src/users/users.rs
+++ b/src/users/users.rs
@@ -5,13 +5,15 @@ use crate::{
     auth::Connected,
     constants::{DRACOON_API_PREFIX, USERS_BASE, USERS_LAST_ADMIN_ROOMS},
     utils::FromResponse,
-    Dracoon, DracoonClientError, ListAllParams, Users,
+    DracoonClientError, ListAllParams, Users,
 };
 
-use super::{CreateUserRequest, LastAdminUserRoomList, UpdateUserRequest, UserData, UserList};
+use super::{
+    CreateUserRequest, LastAdminUserRoomList, UpdateUserRequest, UserData, UserList, UsersEndpoint,
+};
 
 #[async_trait]
-impl Users for Dracoon<Connected> {
+impl Users for UsersEndpoint<Connected> {
     async fn get_users(
         &self,
         params: Option<ListAllParams>,
@@ -20,7 +22,7 @@ impl Users for Dracoon<Connected> {
     ) -> Result<UserList, DracoonClientError> {
         let params = params.unwrap_or_default();
         let url_part = format!("/{DRACOON_API_PREFIX}/{USERS_BASE}");
-        let mut api_url = self.build_api_url(&url_part);
+        let mut api_url = self.client().build_api_url(&url_part);
 
         let filters = params.filter_to_string();
         let sorts = params.sort_to_string();
@@ -36,10 +38,13 @@ impl Users for Dracoon<Connected> {
             .finish();
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -48,13 +53,16 @@ impl Users for Dracoon<Connected> {
 
     async fn create_user(&self, req: CreateUserRequest) -> Result<UserData, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{USERS_BASE}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .post(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&req)
             .send()
@@ -69,13 +77,16 @@ impl Users for Dracoon<Connected> {
         effective_roles: Option<bool>,
     ) -> Result<UserData, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{USERS_BASE}/{user_id}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -88,13 +99,16 @@ impl Users for Dracoon<Connected> {
         req: UpdateUserRequest,
     ) -> Result<UserData, DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{USERS_BASE}/{user_id}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .put(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .header(header::CONTENT_TYPE, "application/json")
             .json(&req)
             .send()
@@ -105,13 +119,16 @@ impl Users for Dracoon<Connected> {
 
     async fn delete_user(&self, user_id: u64) -> Result<(), DracoonClientError> {
         let url_part = format!("/{DRACOON_API_PREFIX}/{USERS_BASE}/{user_id}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .delete(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 
@@ -130,13 +147,16 @@ impl Users for Dracoon<Connected> {
     ) -> Result<LastAdminUserRoomList, DracoonClientError> {
         let url_part =
             format!("/{DRACOON_API_PREFIX}/{USERS_BASE}/{user_id}/{USERS_LAST_ADMIN_ROOMS}");
-        let api_url = self.build_api_url(&url_part);
+        let api_url = self.client().build_api_url(&url_part);
 
         let response = self
-            .client
+            .client()
             .http
             .get(api_url)
-            .header(header::AUTHORIZATION, self.get_auth_header().await?)
+            .header(
+                header::AUTHORIZATION,
+                self.client().get_auth_header().await?,
+            )
             .send()
             .await?;
 


### PR DESCRIPTION
** breaking changes **
Traits are no longer implemented for global client - instead, endpoints implement respective traits (example: `client.nodes.get_nodes(...)`) 
Traits that need to access system info and / or encryption are not affected (`Upload`, `Download`, `MissingFileKeys`) and still only implemented by the global client (example: `client.download(...)`)