### PR TITLE
fix: mfa_enforced serialized as camelCase

### DIFF
--- a/src/users/models.rs
+++ b/src/users/models.rs
@@ -130,6 +130,7 @@ pub struct CreateUserRequest {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MfaConfig {
     mfa_enforced: bool,
 }


### PR DESCRIPTION
fix: creating user with mfa_enforced fails due to wrong serialization