### PR TITLE
fix(shares): rename struct fields of CreateUploadShareRequest to camelCase

### DIFF
--- a/src/shares/models/upload.rs
+++ b/src/shares/models/upload.rs
@@ -73,6 +73,7 @@ impl UploadShareLinkEmail {
 }
 
 #[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateUploadShareRequest {
     target_id: u64,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
- Added #[serde(rename_all = "camelCase")] macro on CreateUploadShareRequest